### PR TITLE
[FEAT] : 모임방 생성 페이지 구현

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -17,9 +17,9 @@
   --color-fill: #f9f9f9;
 
   --text-2xl: 48px;
-  --text-xl: 24px;
+  --text-xl: 22px;
   --text-lg: 20px;
-  --text-md: 16px;
+  --text-md: 18px;
   --text-sm: 14px;
 
   --radius-10: 10px;
@@ -81,7 +81,7 @@
   }
 
   .title {
-    @apply text-lg font-semibold;
+    @apply text-md font-semibold;
   }
 }
 

--- a/src/app/stackflow/stackflow.ts
+++ b/src/app/stackflow/stackflow.ts
@@ -1,13 +1,14 @@
-import { basicUIPlugin } from '@stackflow/plugin-basic-ui'
-import { basicRendererPlugin } from '@stackflow/plugin-renderer-basic'
-import { stackflow } from '@stackflow/react'
+import { basicUIPlugin } from '@stackflow/plugin-basic-ui';
+import { basicRendererPlugin } from '@stackflow/plugin-renderer-basic';
+import { stackflow } from '@stackflow/react';
 
-import { HomeScreen } from '@/screen/home'
-import { UserScreen } from '@/screen/user'
+import { HomeScreen } from '@/screen/home';
+import { UserScreen } from '@/screen/user';
+import { CreateScreen } from '@/screen/create/ui';
 
 export const { Stack, useFlow } = stackflow({
   transitionDuration: 350,
-  activities: { HomeScreen, UserScreen },
+  activities: { HomeScreen, UserScreen, CreateScreen },
   plugins: [
     basicRendererPlugin(),
     basicUIPlugin({
@@ -15,4 +16,4 @@ export const { Stack, useFlow } = stackflow({
     }),
   ],
   initialActivity: () => 'HomeScreen',
-})
+});

--- a/src/screen/create/ui/CreateScreen.tsx
+++ b/src/screen/create/ui/CreateScreen.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { AppScreen } from '@stackflow/plugin-basic-ui';
+
+import { Appbar, Dock } from '@/shared/ui';
+import { CreateContainer } from '@/widgets/create/ui';
+
+export default function CreateScreen() {
+  return (
+    <AppScreen appBar={Appbar}>
+      <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-20'>
+        <CreateContainer />
+      </div>
+      <Dock />
+    </AppScreen>
+  );
+}

--- a/src/screen/create/ui/CreateScreen.tsx
+++ b/src/screen/create/ui/CreateScreen.tsx
@@ -8,7 +8,7 @@ import { CreateContainer } from '@/widgets/create/ui';
 export default function CreateScreen() {
   return (
     <AppScreen appBar={NormalAppBar('모임방 생성')}>
-      <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-20'>
+      <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6'>
         <CreateContainer />
       </div>
     </AppScreen>

--- a/src/screen/create/ui/CreateScreen.tsx
+++ b/src/screen/create/ui/CreateScreen.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 
-import { Appbar, Dock } from '@/shared/ui';
+import { NormalAppBar } from '@/shared/ui';
 import { CreateContainer } from '@/widgets/create/ui';
 
 export default function CreateScreen() {
   return (
-    <AppScreen appBar={Appbar}>
+    <AppScreen appBar={NormalAppBar('모임방 생성')}>
       <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-20'>
         <CreateContainer />
       </div>
-      <Dock />
     </AppScreen>
   );
 }

--- a/src/screen/create/ui/index.ts
+++ b/src/screen/create/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as CreateScreen } from './CreateScreen';

--- a/src/screen/home/HomeScreen.tsx
+++ b/src/screen/home/HomeScreen.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import { AppScreen } from '@stackflow/plugin-basic-ui'
-import { Appbar, Dock } from '@/shared/ui'
-import { HomeContainer } from '@/widgets/home/ui'
+import React from 'react';
+import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { AppBar, Dock } from '@/shared/ui';
+import { HomeContainer } from '@/widgets/home/ui';
 
 export default function HomeScreen() {
   return (
-    <AppScreen appBar={Appbar}>
+    <AppScreen appBar={AppBar()}>
       <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-20'>
         <HomeContainer />
       </div>
       <Dock />
     </AppScreen>
-  )
+  );
 }

--- a/src/screen/user/UserScreen.tsx
+++ b/src/screen/user/UserScreen.tsx
@@ -1,10 +1,10 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { Appbar, Dock } from '@/shared/ui';
+import { AppBar, Dock } from '@/shared/ui';
 import { UserContainer } from '@/widgets/user/ui';
 
 export default function UserScreen() {
   return (
-    <AppScreen appBar={Appbar}>
+    <AppScreen appBar={AppBar()}>
       <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-19'>
         <UserContainer />
       </div>

--- a/src/shared/constants/dock.tsx
+++ b/src/shared/constants/dock.tsx
@@ -3,20 +3,21 @@ import {
   RiHome9Line,
   RiUser3Fill,
   RiUser3Line,
-} from 'react-icons/ri'
-import { DockItem } from '../types/dock'
+} from 'react-icons/ri';
+import { DockItem } from '../types/dock';
+import { PATH } from './path';
 
 export const DOCK = {
-  HomeScreen: {
+  [PATH.HOME]: {
     title: '홈',
     icon: <RiHome9Line size={20} />,
     selectedIcon: <RiHome9Fill size={20} />,
   },
-  UserScreen: {
+  [PATH.USER]: {
     title: '프로필',
     icon: <RiUser3Line size={20} />,
     selectedIcon: <RiUser3Fill size={20} />,
   },
-}
+};
 
-export const DOCK_ITEMS = Object.keys(DOCK) as Array<DockItem>
+export const DOCK_ITEMS = Object.keys(DOCK) as Array<DockItem>;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,2 @@
-export * from './dock'
+export * from './dock';
+export * from './path';

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -1,0 +1,5 @@
+export const PATH = {
+  HOME: 'HomeScreen',
+  USER: 'UserScreen',
+  CREATE: 'CreateScreen',
+} as const;

--- a/src/shared/ui/AppBar.tsx
+++ b/src/shared/ui/AppBar.tsx
@@ -1,4 +1,4 @@
-export const Appbar = {
+export const AppBar = () => ({
   renderLeft: () => (
     <span className='agbalumo-regular ml-2 text-lg font-bold'>Festamate!</span>
   ),
@@ -13,21 +13,10 @@ export const Appbar = {
   ),
   height: '60px',
   backgroundColor: '#f4f4f4',
-}
+});
 
-export const SearchAppbar = {
-  renderLeft: () => (
-    <span className='agbalumo-regular ml-2 text-lg font-bold' />
-  ),
-  renderRight: () => (
-    <div
-      className='mr-2 size-10 rounded-[50%] bg-cover bg-center'
-      style={{
-        backgroundImage:
-          'url(https://i.pinimg.com/736x/04/15/e3/0415e3a6c56fc6e8f1e0ac1bed4b6aaf.jpg)',
-      }}
-    />
-  ),
+export const NormalAppBar = (title?: string) => ({
+  title: title,
   height: '60px',
-  backgroundColor: '#f4f4f4',
-}
+  backgroundColor: '#fff',
+});

--- a/src/shared/ui/FormItem.tsx
+++ b/src/shared/ui/FormItem.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface FormItemProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  childrenWrapper?: boolean;
+}
+
+export default function FormItem({
+  title,
+  description,
+  children,
+  childrenWrapper = true,
+}: FormItemProps) {
+  return (
+    <div className='flex flex-col gap-y-3'>
+      <div className='flex flex-col'>
+        <span className='title'>{title}</span>
+        <span className='text-light'>{description}</span>
+      </div>
+      {childrenWrapper ? (
+        <div className='bg-fill border-border rounded-5 flex w-fit gap-x-4 border-[1px] px-4 py-2'>
+          {children}
+        </div>
+      ) : (
+        <>{children}</>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -10,6 +10,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export default function Input({
+  id,
   placeholder = '',
   type,
   value,
@@ -23,6 +24,8 @@ export default function Input({
     <div className='flex flex-col gap-y-1.5'>
       {label && <span className={cn(labelClassName)}>{label}</span>}
       <input
+        id={id}
+        name={id}
         className={cn(
           'bg-fill border-border rounded-5 w-full border-[1px] px-4 py-2 focus:outline-none',
           className,

--- a/src/shared/ui/Radio.tsx
+++ b/src/shared/ui/Radio.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface RadioProps {
+  id: string;
+  checked?: boolean;
+  label: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function Radio({
+  id,
+  checked = false,
+  label,
+  onChange = () => {},
+}: RadioProps) {
+  return (
+    <div className='flex items-center gap-x-2'>
+      <input
+        type='radio'
+        id={id}
+        name={id}
+        value={id}
+        checked={checked}
+        onChange={onChange}
+      />
+      <label htmlFor={id}>{label}</label>
+    </div>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -2,4 +2,6 @@ export { default as Dock } from './Dock';
 export { default as Card } from './Card';
 export { default as Input } from './Input';
 export { default as Toggle } from './Toggle';
+export { default as Radio } from './Radio';
+export { default as FormItem } from './FormItem';
 export * from './AppBar';

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+import { cn } from '@/shared/utils';
+import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
+
+export default function CreateContainer() {
+  const MODE = [
+    { title: '세부 정보', form: <GroupDetailForm /> },
+    { title: '제목 설명', form: <GroupTitleForm /> },
+  ];
+  const [mode, setMode] = useState(0);
+
+  return (
+    <div className='flex size-full flex-col justify-between'>
+      <div className='flex flex-col gap-y-6'>
+        <div className='flex w-fit'>
+          {MODE.map(({ title }, index) => (
+            <button
+              key={title}
+              className={cn(
+                'border-sub text-md text-light border-b-2 px-3 py-2 font-semibold focus:outline-none',
+                MODE[mode].title === title && 'text-dark border-black',
+              )}
+              name='group-data-details'
+              onClick={() => setMode(index)}
+            >
+              {title}
+            </button>
+          ))}
+        </div>
+        {MODE[mode].form}
+      </div>
+      <button>다음으로</button>
+    </div>
+  );
+}

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -5,8 +5,8 @@ import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
 
 export default function CreateContainer() {
   const MODE = [
-    { title: '세부 정보', form: <GroupDetailForm /> },
-    { title: '제목 설명', form: <GroupTitleForm /> },
+    { title: '세부 정보', form: <GroupDetailForm />, button: '다음으로' },
+    { title: '제목 설명', form: <GroupTitleForm />, button: '생성하기' },
   ];
   const [mode, setMode] = useState(0);
 
@@ -22,7 +22,9 @@ export default function CreateContainer() {
                 MODE[mode].title === title && 'text-dark border-black',
               )}
               name='group-data-details'
-              onClick={() => setMode(index)}
+              onClick={() => {
+                if (index === 0) setMode(index);
+              }}
             >
               {title}
             </button>
@@ -30,7 +32,12 @@ export default function CreateContainer() {
         </div>
         {MODE[mode].form}
       </div>
-      <button>다음으로</button>
+      <button
+        className='box-shadow-buttonLg rounded-10 text-md hover:bg-primary-hover z-30 mb-6 h-16 w-full flex-shrink-0 cursor-pointer bg-[#775bf0] font-semibold text-white'
+        onClick={() => setMode(prev => (prev === 0 ? 1 : 1))}
+      >
+        {MODE[mode].button}
+      </button>
     </div>
   );
 }

--- a/src/widgets/create/ui/GroupDetailForm.tsx
+++ b/src/widgets/create/ui/GroupDetailForm.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { FormItem, Input, Radio } from '@/shared/ui';
+
+export default function GroupDetailForm() {
+  return (
+    <>
+      <FormItem
+        title='인원 선택'
+        description='1:1은 2명, 2:2는 4명, 3:3은 6명을 선택해주세요.'
+      >
+        <Radio id='people-2' label='2명' />
+        <Radio id='people-4' label='4명' />
+        <Radio id='people-6' label='6명' />
+      </FormItem>
+      <FormItem
+        title='성별 선택'
+        description='1:1은 2명, 2:2는 4명, 3:3은 6명을 선택해주세요.'
+      >
+        <Radio id='male' label='남자' />
+        <Radio id='female' label='여자' />
+      </FormItem>
+      <FormItem
+        title='연락 수단'
+        description='구성원들에게 연락할 수 있는 링크를 알려주세요.'
+        childrenWrapper={false}
+      >
+        <Input placeholder='링크를 입력해주세요.' />
+      </FormItem>
+      <FormItem
+        title='모임 날짜'
+        description='모임 날짜를 입력해주세요'
+        childrenWrapper={false}
+      >
+        <Input placeholder='DatePicker 개발 예정' />
+      </FormItem>
+    </>
+  );
+}

--- a/src/widgets/create/ui/GroupTitleForm.tsx
+++ b/src/widgets/create/ui/GroupTitleForm.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { FormItem, Input } from '@/shared/ui';
+
+export default function GroupTitleForm() {
+  return (
+    <>
+      <FormItem title='모임방 제목' childrenWrapper={false}>
+        <Input placeholder='제목을 입력해주세요.' />
+      </FormItem>
+      <FormItem title='모임방 설명' childrenWrapper={false}>
+        <Input placeholder='설명을 입력해주세요.' />
+      </FormItem>
+    </>
+  );
+}

--- a/src/widgets/create/ui/GroupTitleForm.tsx
+++ b/src/widgets/create/ui/GroupTitleForm.tsx
@@ -6,10 +6,15 @@ export default function GroupTitleForm() {
   return (
     <>
       <FormItem title='모임방 제목' childrenWrapper={false}>
-        <Input placeholder='제목을 입력해주세요.' />
+        <Input id='group-title' placeholder='제목을 입력해주세요.' />
       </FormItem>
       <FormItem title='모임방 설명' childrenWrapper={false}>
-        <Input placeholder='설명을 입력해주세요.' />
+        <textarea
+          id='group-desc'
+          name='group-desc'
+          placeholder='설명을 입력해주세요.'
+          className='bg-fill border-border rounded-5 h-60 w-full resize-none border-[1px] px-4 py-2 focus:outline-none'
+        />
       </FormItem>
     </>
   );

--- a/src/widgets/create/ui/index.ts
+++ b/src/widgets/create/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as CreateContainer } from './CreateContainer';
+export { default as GroupDetailForm } from './GroupDetailForm';
+export { default as GroupTitleForm } from './GroupTitleForm';

--- a/src/widgets/home/ui/HomeContainer.tsx
+++ b/src/widgets/home/ui/HomeContainer.tsx
@@ -1,18 +1,28 @@
-import React from 'react'
+import React from 'react';
 
-import { GroupCarousel } from '@/widgets/home/ui'
+import { GroupCarousel } from '@/widgets/home/ui';
+import { useFlow } from '@/app/stackflow';
+import { PATH } from '@/shared/constants';
 
 export default function HomeContainer() {
+  const { push } = useFlow();
+
+  const onClick = () => push(PATH.CREATE, {});
+
   return (
     <>
       <BoothInfo />
       <GroupCarousel label='개설된 모임방' key='openedGroup' />
       <GroupCarousel label='참여한 모임방' key='joinedGroup' />
-      <button className='box-shadow-buttonLg rounded-10 text-md hover:bg-primary-hover z-30 mb-6 h-16 w-full flex-shrink-0 cursor-pointer bg-[#775bf0] font-semibold text-white'>
+      <button
+        name='create-group'
+        className='box-shadow-buttonLg rounded-10 text-md hover:bg-primary-hover z-30 mb-6 h-16 w-full flex-shrink-0 cursor-pointer bg-[#775bf0] font-semibold text-white'
+        onClick={onClick}
+      >
         모임방 생성하기
       </button>
     </>
-  )
+  );
 }
 
 const BoothInfo = () => (
@@ -25,4 +35,4 @@ const BoothInfo = () => (
     </div>
     <span className='text-xl font-semibold'>부스에 방문해보세요!</span>
   </div>
-)
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#7 

## 📝 작업 내용

> 모임방 생성 페이지를 구현했어요.
- 모임방 생성 페이지 컴포넌트를 추가했어요.
- 기존 `stackflow` 라우팅 방식의 편의를 위해 최상단 `screen` 컴포넌트를 상수로 정의했어요.
- `AppBar`, `FormItem`, `Radio`, `Input` 과 같은 공유 컴포넌트를 구현했어요.

### 스크린샷 (선택)

<img width="341" alt="image" src="https://github.com/user-attachments/assets/ea4f3916-b654-4096-bef6-c9f759d1b8b7" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/c8203a42-018a-4c7b-a7ef-fb6f1497142d" />


## 💬 추가 명시

DTO가 확정되지 않아 화면 구성이 수정될 여지가 있어 기능은 구현하지 않았어요.
화면 확정 시 `DatePicker` 구현과 함께 화면 완성 예정이에요.
