### PR TITLE
[FIX] : 스택 꼬임으로 인한 뒤로 가기 버튼 렌더링 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
     <meta charset="UTF-8" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/x-icon" href="/favicon/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
     <meta property="og:url" content="" />
     <meta property="og:title" content="축제를 더 즐겁게, Festamate!" />
     <meta property="og:type" content="website" />
@@ -31,12 +34,12 @@
         navigator.serviceWorker
           .register('/firebase-messaging-sw.js')
           .then(registration => {
-            console.log('Service Worker 등록 성공:', registration.scope)
+            console.log('Service Worker 등록 성공:', registration.scope);
           })
           .catch(error => {
-            console.log('Service Worker 등록 실패:', error)
-          })
-      })
+            console.log('Service Worker 등록 실패:', error);
+          });
+      });
     }
   </script>
 </html>

--- a/src/shared/ui/AppBar.tsx
+++ b/src/shared/ui/AppBar.tsx
@@ -16,6 +16,7 @@ export const AppBar = (searchOnClick: () => void) => ({
       <FiSearch size={24} />
     </button>
   ),
+  closeButton: { renderIcon: () => <></> },
   ...baseStyle,
 });
 
@@ -34,7 +35,6 @@ export const SearchAppBar = (searchOnClick: () => void) => ({
   renderRight: () => (
     <FiSearch size={24} onClick={searchOnClick} className='mr-2' />
   ),
-
   ...baseStyle,
   backgroundColor: '#fff',
 });

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -1,19 +1,19 @@
-import React from 'react'
+import React from 'react';
 
-import { useFlow } from '@/app/stackflow'
-import { useStack } from '@stackflow/react'
-import { DOCK, DOCK_ITEMS } from '@/shared/constants'
-import { DockItem } from '@/shared/types'
+import { useFlow } from '@/app/stackflow';
+import { useStack } from '@stackflow/react';
+import { DOCK, DOCK_ITEMS } from '@/shared/constants';
+import { DockItem } from '@/shared/types';
 
 interface DockButtonProps {
-  item: DockItem
-  selected: boolean
+  item: DockItem;
+  selected: boolean;
 }
 
 export default function Dock() {
-  const stack = useStack()
-  const info = stack.activities
-  const current = info[info.length - 1].name as DockItem
+  const stack = useStack();
+  const info = stack.activities;
+  const current = info[info.length - 1].name as DockItem;
 
   return (
     <div className='dock box-shadow-dock container-mobile fixed right-0 bottom-0 left-0 z-60 flex h-18 items-center justify-between border-none p-7'>
@@ -21,18 +21,27 @@ export default function Dock() {
         <DockButton key={item} item={item} selected={current === item} />
       ))}
     </div>
-  )
+  );
 }
 
 const DockButton = ({ item, selected }: DockButtonProps) => {
-  const { replace } = useFlow()
+  const stack = useStack();
+  const { replace, pop } = useFlow();
+
   const onClick = () => {
-    replace(item, { animate: false }, { animate: false })
-  }
+    replace(item, { animate: false }, { animate: false });
+    const info = stack.activities;
+    if (
+      info.filter(activity => activity.transitionState === 'enter-done')
+        .length > 0
+    ) {
+      pop();
+    }
+  };
 
   return (
     <div className='size-20' onClick={onClick}>
       {selected ? DOCK[item].selectedIcon : DOCK[item].icon}
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #12 

## 📝 작업 내용

> 기존 스택 꼬임 이슈로 인해 불필요하게 생성되던 뒤로 가기 버튼을 제거했어요.
- `Dock` 에서 네비게이션 시, 기존 스택에 `enter-done` 상태의 액티비티가 존재한다면, 이 액티비티가 현재 이동하고자 하는 액티비티와 동일한 것으로 간주하고(다른 동작을 수행하더라도 모두 `push` 후 `replace` 이기에 항상 스택 내부에 남게 되는 것은 초기 액티비티인 `Home` 일 수밖에 없다 판단) `pop` 연산을 수행하도록 수정했어요.
- 만약 해당 변경으로 인해 차후 화면 추가 시 오류가 생긴다면, #12 이슈 아래 하위 이슈를 생성할 예정이에요.
- `initial-scale`, `maximum-scale`, `minimun-scale` 값을 통일하여 화면 확대를 방지했어요.

