### PR TITLE
[FIX] : 네비게이션 메소드 변경, 스택 안정화

### DIFF
--- a/src/screen/home/HomeScreen.tsx
+++ b/src/screen/home/HomeScreen.tsx
@@ -8,8 +8,8 @@ import { useFlow } from '@/app/stackflow';
 import { PATH } from '@/shared/constants';
 
 export default function HomeScreen() {
-  const { push } = useFlow();
-  const searchOnClick = () => push(PATH.SEARCH, {});
+  const { replace } = useFlow();
+  const searchOnClick = () => replace(PATH.SEARCH, {});
 
   return (
     <AppScreen appBar={AppBar(searchOnClick)}>

--- a/src/screen/result/ui/ResultScreen.tsx
+++ b/src/screen/result/ui/ResultScreen.tsx
@@ -8,18 +8,20 @@ import { SearchAppBar, Dock } from '@/shared/ui';
 import { ResultContainer } from '@/widgets/result/ui';
 
 export default function ResultScreen() {
-  const { replace } = useFlow();
-  const onClick = () => replace(PATH.RESULT, {}, { animate: false });
+  const { replace, push } = useFlow();
+  const closeOnClick = () => replace(PATH.HOME, {});
+  const searchOnClick = () => replace(PATH.RESULT, {}, { animate: false });
+  const createOnClick = () => push(PATH.CREATE, {});
 
   return (
-    <AppScreen appBar={SearchAppBar(onClick)}>
+    <AppScreen appBar={SearchAppBar(closeOnClick, searchOnClick)}>
       <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6 pb-24'>
         <ResultContainer searchKey='과팅' />
       </div>
       <button
         name='create-group'
         className='box-shadow-buttonLg rounded-10 text-md hover:bg-primary-hover absolute right-6 bottom-24 z-30 w-fit flex-shrink-0 cursor-pointer bg-[#775bf0] px-4 py-2 font-semibold text-white'
-        onClick={onClick}
+        onClick={createOnClick}
       >
         +
       </button>

--- a/src/screen/search/ui/SearchScreen.tsx
+++ b/src/screen/search/ui/SearchScreen.tsx
@@ -9,10 +9,11 @@ import { PATH } from '@/shared/constants';
 
 export default function SearchScreen() {
   const { replace } = useFlow();
-  const onClick = () => replace(PATH.RESULT, {}, { animate: false });
+  const closeOnClick = () => replace(PATH.HOME, {});
+  const searchOnClick = () => replace(PATH.RESULT, {}, { animate: false });
 
   return (
-    <AppScreen appBar={SearchAppBar(onClick)}>
+    <AppScreen appBar={SearchAppBar(closeOnClick, searchOnClick)}>
       <div className='scrollbar-hide container-mobile flex size-full flex-col gap-y-6 overflow-scroll overflow-y-scroll p-6'>
         <SearchContainer />
       </div>

--- a/src/shared/ui/AppBar.tsx
+++ b/src/shared/ui/AppBar.tsx
@@ -1,4 +1,4 @@
-import { FiSearch } from 'react-icons/fi';
+import { FiChevronLeft, FiSearch } from 'react-icons/fi';
 import Input from './Input';
 
 const baseStyle = { height: '64px', backgroundColor: '#f4f4f4' };
@@ -25,12 +25,18 @@ export const NormalAppBar = (title?: string) => ({
   ...baseStyle,
 });
 
-export const SearchAppBar = (searchOnClick: () => void) => ({
+export const SearchAppBar = (
+  closeOnClick: () => void,
+  searchOnClick: () => void,
+) => ({
   renderLeft: () => (
-    <Input
-      className='ml-6 w-[calc(100vw-132px)]'
-      placeholder='검색어를 입력하세요'
-    />
+    <>
+      <FiChevronLeft size={32} onClick={closeOnClick} />
+      <Input
+        className='ml-3 w-[calc(100vw-132px)]'
+        placeholder='검색어를 입력하세요'
+      />
+    </>
   ),
   renderRight: () => (
     <FiSearch size={24} onClick={searchOnClick} className='mr-2' />

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -25,18 +25,9 @@ export default function Dock() {
 }
 
 const DockButton = ({ item, selected }: DockButtonProps) => {
-  const stack = useStack();
-  const { replace, pop } = useFlow();
-
+  const { replace } = useFlow();
   const onClick = () => {
     replace(item, { animate: false }, { animate: false });
-    const info = stack.activities;
-    if (
-      info.filter(activity => activity.transitionState === 'enter-done')
-        .length > 0
-    ) {
-      pop();
-    }
   };
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #12 

기존 #12 에서 다루었던 이슈를 해결한 코드가 다른 오류를 발생시켰어요(Dock에 누른 버튼에 해당하는 화면으로 이동하지 않는 오류). <br/>이에 다시 이슈를 오픈하고 해결합니다.

## 📝 작업 내용

> 네비게이션 메소드를 모두 `replace` 로 변경했어요 (create screen 제외)
- 모두 `replace` 네비게이션을 진행하여 예상하지 못한 기본 close button 렌더링을 방지했어요
- 기본 close button이 렌더링되지 않는 대신 필요한 부분에 직접 close button과 핸들러를 구현했어요

### 스크린샷 (선택)

<img width="340" alt="image" src="https://github.com/user-attachments/assets/e8c57acc-9505-4682-ac1b-ba7f9f1b7f32" />

앱바에 들어가는 close button을 직접 구현하고, 이벤트 핸들러 또한 직접 구현해 넣었습니다.
이제 오류가 발생하지 않습니다!
