### PR TITLE
[FEAT] : 모임방 상세 조회 페이지 구현

### DIFF
--- a/src/app/stackflow/stackflow.ts
+++ b/src/app/stackflow/stackflow.ts
@@ -8,6 +8,7 @@ import { CreateScreen } from '@/screen/create/ui';
 import { SearchScreen } from '@/screen/search/ui';
 import { ResultScreen } from '@/screen/result/ui';
 import { ListScreen } from '@/screen/list/ui';
+import { RoomScreen } from '@/screen/room/ui';
 
 export const { Stack, useFlow } = stackflow({
   transitionDuration: 350,
@@ -18,6 +19,7 @@ export const { Stack, useFlow } = stackflow({
     SearchScreen,
     ResultScreen,
     ListScreen,
+    RoomScreen,
   },
   plugins: [
     basicRendererPlugin(),

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,0 +1,1 @@
+export * from './room';

--- a/src/mock/room.ts
+++ b/src/mock/room.ts
@@ -1,0 +1,39 @@
+import { RoomParticipant } from '@/widgets/room/types';
+
+export const ROOM_MAKERS: RoomParticipant[] = [
+  {
+    id: 1,
+    nickname: '코딩천재',
+    studentId: '201912134',
+    gender: 'MALE',
+    department: 'AI컴퓨터공학부',
+    isHost: true,
+  },
+  {
+    id: 2,
+    nickname: '버그헌터',
+    studentId: '201912134',
+    gender: 'MALE',
+    department: 'AI컴퓨터공학부',
+    isHost: false,
+  },
+];
+
+export const ROOM_PARTICIPANTS: RoomParticipant[] = [
+  {
+    id: 1,
+    nickname: '소프트요정',
+    studentId: '201912134',
+    gender: 'FEMALE',
+    department: '관광문화대학',
+    isHost: true,
+  },
+  {
+    id: 2,
+    nickname: '버블티공주',
+    studentId: '201912134',
+    gender: 'FEMALE',
+    department: '관광문화대학',
+    isHost: false,
+  },
+];

--- a/src/screen/list/ui/ListScreen.tsx
+++ b/src/screen/list/ui/ListScreen.tsx
@@ -14,7 +14,7 @@ const ListScreen: ActivityComponentType<ListScreenParams> = ({
 }) => {
   return (
     <AppScreen appBar={NormalAppBar(params.title)}>
-      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding pb-dock-height flex size-full flex-col overflow-scroll overflow-y-scroll'>
+      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding pb-dock-height flex size-full flex-col overflow-y-scroll'>
         <ListContainer />
       </div>
     </AppScreen>

--- a/src/screen/list/ui/ListScreen.tsx
+++ b/src/screen/list/ui/ListScreen.tsx
@@ -14,7 +14,7 @@ const ListScreen: ActivityComponentType<ListScreenParams> = ({
 }) => {
   return (
     <AppScreen appBar={NormalAppBar(params.title)}>
-      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding flex size-full flex-col overflow-scroll overflow-y-scroll pb-24'>
+      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding pb-dock-height flex size-full flex-col overflow-scroll overflow-y-scroll'>
         <ListContainer />
       </div>
     </AppScreen>

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -1,0 +1,24 @@
+import { ActivityComponentType } from '@stackflow/react';
+import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { NormalAppBar } from '@/shared/ui';
+import { RoomContainer } from '@/widgets/room/ui';
+
+type RoomScreenParams = {
+  title: string;
+};
+
+const RoomScreen: ActivityComponentType<RoomScreenParams> = ({
+  params,
+}: {
+  params: RoomScreenParams;
+}) => {
+  return (
+    <AppScreen appBar={NormalAppBar(params.title)}>
+      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding flex size-full flex-col overflow-scroll overflow-y-scroll'>
+        <RoomContainer />
+      </div>
+    </AppScreen>
+  );
+};
+
+export default RoomScreen;

--- a/src/screen/room/ui/index.ts
+++ b/src/screen/room/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as RoomScreen } from './RoomScreen';

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -5,4 +5,5 @@ export const PATH = {
   SEARCH: 'SearchScreen',
   RESULT: 'ResultScreen',
   LIST: 'ListScreen',
+  ROOM: 'RoomScreen',
 } as const;

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,33 @@
+import React, { ButtonHTMLAttributes } from 'react';
+
+import { cn } from '@/shared/utils';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  disabled?: boolean;
+  halfWidth?: boolean;
+}
+
+export default function Button({
+  onClick,
+  disabled,
+  label,
+  name,
+  type,
+  halfWidth = false,
+}: ButtonProps) {
+  return (
+    <button
+      name={name}
+      type={type || 'button'}
+      className={cn(
+        'disabled:bg-sub disabled:text-border box-shadow-buttonLg rounded-10 hover:bg-primary-hover mb-normal-spacing bg-point z-30 h-16 flex-shrink-0 cursor-pointer text-lg font-semibold text-white transition duration-300',
+        halfWidth ? 'flex-1' : 'w-full',
+      )}
+      disabled={disabled ?? false}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/shared/ui/Card.tsx
+++ b/src/shared/ui/Card.tsx
@@ -3,19 +3,24 @@ import React from 'react';
 import { RiUser3Fill } from 'react-icons/ri';
 import { IoMdFemale } from 'react-icons/io';
 
-import { cn } from '@/shared/utils';
+import { useFlow } from '@/app/stackflow';
+import { PATH } from '@/shared/constants';
 
-export default function Card({ sizePreset = true }: { sizePreset?: boolean }) {
+export default function Card() {
+  const { push } = useFlow();
+  const handleClick = () => {
+    push(PATH.ROOM, { title: '모임방 상세' });
+  };
+
   return (
-    <div
-      className={cn(
-        'card rounded-10 relative flex-shrink-0 bg-cover bg-center shadow-sm',
-        sizePreset ? 'h-card-height w-44' : 'h-60 w-full',
-      )}
+    <button
+      name='room-card'
+      className='card rounded-10 h-card-height relative w-44 flex-shrink-0 bg-cover bg-center shadow-sm'
       style={{
         backgroundImage:
           'url(https://i.pinimg.com/736x/81/09/5c/81095c402f3fda5bff8cb19692d96dd9.jpg)',
       }}
+      onClick={handleClick}
     >
       <div className='rounded-10 absolute inset-0 z-0 bg-black/40 bg-gradient-to-b from-transparent from-0% via-transparent via-50% to-black/60 to-100%' />
       <div className='absolute top-0 z-10 flex w-fit items-center gap-x-2 p-4 text-sm text-white'>
@@ -35,6 +40,6 @@ export default function Card({ sizePreset = true }: { sizePreset?: boolean }) {
           <p className='text-sub text-sm'>1월 27일 18:00</p>
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/shared/ui/ListItem.tsx
+++ b/src/shared/ui/ListItem.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
+
 import { RiUser3Fill } from 'react-icons/ri';
 
+import { useFlow } from '@/app/stackflow';
+
+import { PATH } from '@/shared/constants';
+
 export default function ListItem() {
+  const { push } = useFlow();
+  const handleClick = () => {
+    push(PATH.ROOM, { title: '모임방 상세' });
+  };
+
   return (
-    <div className='border-border rounded-10 grid h-28 w-full grid-cols-[1fr_4fr] gap-3 py-3'>
+    <button
+      name='listitem'
+      className='border-border rounded-10 grid h-28 w-full cursor-pointer grid-cols-[1fr_4fr] gap-3 py-3 focus:outline-none'
+      onClick={handleClick}
+    >
       <div className='rounded-5 h-full bg-red-500/10'></div>
       <div className='flex h-full flex-col justify-between overflow-hidden'>
-        <div>
+        <div className='flex flex-col items-start'>
           <p className='text-lg font-semibold'>컴공 부스 존맛존 같이 가영</p>
           <p className='w-full overflow-hidden text-nowrap text-ellipsis'>
             컴공 봄부스에서 닭강정한대요@ 컴공 봄부스에서 닭강정한대요@ 컴공
@@ -17,10 +31,10 @@ export default function ListItem() {
         <div className='text-light flex items-center gap-x-2 text-sm'>
           <p>3월 21일 18:00</p>·
           <p className='flex items-center gap-x-1'>
-            <RiUser3Fill size={12} /> 2/6
+            <RiUser3Fill size={12} /> 2:2 모임방
           </p>
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -7,5 +7,6 @@ export { default as FormItem } from './FormItem';
 export { default as ListItem } from './ListItem';
 export { default as GroupCarousel } from './GroupCarousel';
 export { default as GroupList } from './GroupList';
+export { default as Button } from './Button';
 
 export * from './AppBar';

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -3,10 +3,12 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { cn, getCookie, getDate } from '@/shared/utils';
-import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
-import { Room } from '../types';
-import { CONTENT_MAX_LENGTH, TITLE_MAX_LENGTH } from '../model';
 import { post, REQUEST } from '@/shared/api';
+import { Button } from '@/shared/ui';
+
+import { CONTENT_MAX_LENGTH, TITLE_MAX_LENGTH } from '@/widgets/create/model';
+import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
+import { Room } from '@/widgets/create/types';
 
 export default function CreateContainer() {
   const [mode, setMode] = useState(0);
@@ -70,19 +72,18 @@ export default function CreateContainer() {
         </div>
         {MODE[mode].form}
       </div>
-      <button
+      <Button
         name='group-form-submit'
         type='button'
-        className='disabled:bg-sub disabled:text-border box-shadow-buttonLg rounded-10 hover:bg-primary-hover z-30 mb-6 h-16 w-full flex-shrink-0 cursor-pointer bg-[#775bf0] text-lg font-semibold text-white transition duration-300'
+        className='disabled:bg-sub disabled:text-border box-shadow-buttonLg rounded-10 hover:bg-primary-hover mb-normal-spacing bg-point z-30 h-16 w-full flex-shrink-0 cursor-pointer text-lg font-semibold text-white transition duration-300'
         disabled={!MODE[mode].isFormValid}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();
           if (mode === 0) setMode(prev => (prev === 0 ? 1 : 1));
           else handleSubmit();
         }}
-      >
-        {MODE[mode].button}
-      </button>
+        label={MODE[mode].button}
+      />
     </form>
   );
 }

--- a/src/widgets/room/types/index.ts
+++ b/src/widgets/room/types/index.ts
@@ -1,0 +1,1 @@
+export * from './room';

--- a/src/widgets/room/types/room.ts
+++ b/src/widgets/room/types/room.ts
@@ -1,0 +1,19 @@
+export type RoomDetail = {
+  id: number;
+  headCount: number;
+  preferredGender: 'MALE' | 'FEMALE';
+  openChatLink: string;
+  meetingDateTime: string;
+  title: string;
+  content: string;
+  participants: RoomParticipant[];
+};
+
+export type RoomParticipant = {
+  id: number;
+  nickname: string;
+  studentId: string;
+  gender: 'MALE' | 'FEMALE';
+  department: string;
+  isHost: boolean;
+};

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Button, FormItem } from '@/shared/ui';
+import { UserItem, RoomHeader } from '@/widgets/room/ui';
+import { ROOM_MAKERS, ROOM_PARTICIPANTS } from '@/mock';
+
+export default function RoomContainer() {
+  return (
+    <div className='flex size-full flex-col justify-between'>
+      <div className='scrollbar-hide flex flex-col gap-y-6 overflow-scroll'>
+        <RoomHeader />
+        <div className='border-sub flex h-fit w-full border-b-2 pb-6'>
+          컴공 봄부스에서 닭강정한대요@ 컴공 봄부스에서 닭강정한대요@ 컴공
+          봄부스에서 닭강정한대요@ 컴공 봄부스에서 닭강정한대요@ 컴공 봄부스에서
+          닭강정한대요@ 사실 저도 잘 모르는데 같이 가서 보면 좋을 것 같아요!
+        </div>
+        <FormItem title='모임을 연 멤버'>
+          {ROOM_MAKERS.map(m => (
+            <UserItem {...m} key={m.id} />
+          ))}
+        </FormItem>
+        <FormItem title='모임에 참여한 멤버'>
+          {ROOM_PARTICIPANTS.map(m => (
+            <UserItem {...m} key={m.id} />
+          ))}
+        </FormItem>
+        <div className='h-normal-spacing' />
+      </div>
+      <div className='z-30 flex h-16 w-full flex-shrink-0 gap-x-3 text-lg font-semibold text-white'>
+        <Button name='room-participate' label='참여하기' halfWidth />
+        <Button
+          name='room-participate-with-friend'
+          label='친구와 함께 참여하기'
+          halfWidth
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/room/ui/RoomHeader.tsx
+++ b/src/widgets/room/ui/RoomHeader.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { RiUser3Fill } from 'react-icons/ri';
+
+export default function RoomHeader() {
+  return (
+    <div className='rounded-10 grid h-28 w-full cursor-pointer grid-cols-[1fr_4fr] gap-3 py-3'>
+      <div className='rounded-5 h-full bg-red-500/10'></div>
+      <div className='flex h-full flex-col justify-between overflow-hidden'>
+        <div className='flex flex-col items-start'>
+          <p className='text-lg font-semibold'>컴공 부스 존맛존 같이 가영</p>
+          <div className='flex justify-between gap-2 text-lg font-semibold'>
+            <span className='text-point w-fit'>2:2 모임방</span>
+            <span className='w-fit'>3월 21일 18:00</span>
+          </div>
+        </div>
+        <div className='text-light flex items-center gap-x-2 text-sm'>
+          <p className='flex items-center gap-x-1'>
+            모임장<span>·</span>
+            <RiUser3Fill size={12} />
+            유노윤호
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/room/ui/UserItem.tsx
+++ b/src/widgets/room/ui/UserItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { cn } from '@/shared/utils';
+
+import { RoomParticipant } from '@/widgets/room/types';
+
+export default function UserItem({
+  nickname,
+  studentId,
+  gender,
+  department,
+}: RoomParticipant) {
+  const male = gender === 'MALE';
+
+  return (
+    <div className='rounded-10 grid h-15 w-full cursor-pointer grid-cols-[auto_6fr] gap-3 py-1 focus:outline-none'>
+      <div>
+        <div
+          className='size-13 rounded-[50%] bg-cover bg-center'
+          style={{
+            backgroundImage:
+              'url(https://i.pinimg.com/736x/04/15/e3/0415e3a6c56fc6e8f1e0ac1bed4b6aaf.jpg)',
+          }}
+        />
+      </div>
+      <div className='flex size-full flex-col gap-y-1'>
+        <div className='flex w-fit items-center gap-x-2'>
+          <span className='text-lg font-semibold'>{nickname}</span>
+          <span
+            className={cn(
+              'rounded-5 grid w-fit place-items-center border-[0.5px] p-1 px-2 text-[10px]',
+              male ? 'border-male bg-male/20' : 'border-female bg-female/20',
+            )}
+          >
+            {male ? '남성' : '여성'}
+          </span>
+        </div>
+        <div className='flex w-fit items-center gap-x-1'>
+          <span>{department}</span>·
+          <span>{studentId.slice(2, 4)}학번 재학생</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as RoomContainer } from './RoomContainer';
+export { default as RoomHeader } from './RoomHeader';
+export { default as UserItem } from './UserItem';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #18 

## 📝 작업 내용

> 모임방 상세 조회 페이지를 구현했어요.
- 공유 `Button` 컴포넌트를 제작했어요.
- 모임방 상세에 관련한 타입을 정의하고 목업 데이터를 생성했어요.

### 스크린샷 (선택)

<img width="340" alt="image" src="https://github.com/user-attachments/assets/06659ff5-1b13-4385-88ca-1dc766439594" />
