### PR TITLE
[FEAT] : 모임방 생성 기능 구현 완료

### DIFF
--- a/src/mock/room.ts
+++ b/src/mock/room.ts
@@ -2,7 +2,10 @@ export const COVERED_ROOM_DATA = [
   {
     id: 1,
     preferredGender: 'FEMALE',
+    preferredStudentIdMin: 'string',
+    preferredStudentIdMax: 'string',
     meetingDateTime: '2025-04-20T18:30:00Z',
+    status: 'MATCHING',
     title: '한강에서 피크닉할 사람!!',
     content:
       '날씨 좋을 때 한강에서 돗자리 깔고 놀 사람 구해요! 간단한 간식이랑 음료는 제가 준비할게요 :)',
@@ -17,7 +20,10 @@ export const COVERED_ROOM_DATA = [
   {
     id: 2,
     preferredGender: 'MALE',
+    preferredStudentIdMin: 'string',
+    preferredStudentIdMax: 'string',
     meetingDateTime: '2025-04-15T14:00:00Z',
+    status: 'MATCHING',
     title: '보드게임 같이 하실 분 구함',
     content:
       '보드게임 좋아하시는 분들 환영이에요! 다양한 게임 준비되어 있어요. 초보자도 환영합니다.',
@@ -32,7 +38,10 @@ export const COVERED_ROOM_DATA = [
   {
     id: 3,
     preferredGender: 'FEMALE',
+    preferredStudentIdMin: 'string',
+    preferredStudentIdMax: 'string',
     meetingDateTime: '2025-04-18T10:00:00Z',
+    status: 'MATCHING',
     title: '아침 등산 같이 가실 분~',
     content:
       '이른 아침 등산으로 상쾌한 하루 시작해요! 중간에 간단한 간식 타임도 있어요.',

--- a/src/screen/create/ui/CreateScreen.tsx
+++ b/src/screen/create/ui/CreateScreen.tsx
@@ -4,12 +4,15 @@ import { AppScreen } from '@stackflow/plugin-basic-ui';
 
 import { NormalAppBar } from '@/shared/ui';
 import { CreateContainer } from '@/widgets/create/ui';
+import { CreateProvider } from '@/widgets/create/model';
 
 export default function CreateScreen() {
   return (
     <AppScreen appBar={NormalAppBar('모임방 생성')}>
       <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding flex size-full flex-col overflow-scroll overflow-y-scroll'>
-        <CreateContainer />
+        <CreateProvider>
+          <CreateContainer />
+        </CreateProvider>
       </div>
     </AppScreen>
   );

--- a/src/screen/home/ui/HomeScreen.tsx
+++ b/src/screen/home/ui/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { MdAdd } from 'react-icons/md';
@@ -7,10 +7,13 @@ import { AppBar, Button, Dock, LoginBottomSheet } from '@/shared/ui';
 import { HomeContainer } from '@/widgets/home/ui';
 import { useFlow } from '@/app/stackflow';
 import { PATH } from '@/shared/constants';
+import { fetchLoginStatus } from '@/shared/utils';
+import { useSetAtom } from 'jotai';
+import { bottomSheetAtom } from '@/shared/atom';
 
 export default function HomeScreen() {
-  const hasToken = false;
-  const [isOpen, setIsOpen] = useState(false);
+  const hasToken = fetchLoginStatus();
+  const setIsOpen = useSetAtom(bottomSheetAtom);
   const { replace, push } = useFlow();
 
   const searchOnClick = () => replace(PATH.SEARCH, {});
@@ -38,11 +41,7 @@ export default function HomeScreen() {
           }
         />
       </AppScreen>
-      <LoginBottomSheet
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        onClose={() => setIsOpen(false)}
-      />
+      <LoginBottomSheet />
       <Dock />
     </>
   );

--- a/src/shared/atom/bottomSheet.ts
+++ b/src/shared/atom/bottomSheet.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const bottomSheetAtom = atom(false);

--- a/src/shared/atom/index.ts
+++ b/src/shared/atom/index.ts
@@ -1,1 +1,2 @@
 export * from './user';
+export * from './bottomSheet';

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -1,6 +1,6 @@
 import { Gender } from '@/shared/types';
 
-export type Room = {
+export type Room = Partial<FormData> & {
   id: number;
   headCount: 2 | 4 | 6;
   status: string;

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -1,8 +1,10 @@
+import { Gender } from '@/shared/types';
+
 export type Room = {
   id: number;
   headCount: 2 | 4 | 6;
   status: string;
-  preferredGender: 'MALE' | 'FEMALE';
+  preferredGender: Gender;
   preferredStudentIdMin: string;
   preferredStudentIdMax: string;
   meetingDateTime: string;
@@ -20,7 +22,7 @@ export type RoomParticipant = {
   id: number;
   nickname: string;
   studentId: string;
-  gender: 'MALE' | 'FEMALE';
+  gender: Gender;
   major: string;
   isHost: boolean;
 };

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -1,7 +1,10 @@
 export type Room = {
   id: number;
   headCount: 2 | 4 | 6;
+  status: string;
   preferredGender: 'MALE' | 'FEMALE';
+  preferredStudentIdMin: string;
+  preferredStudentIdMax: string;
   meetingDateTime: string;
   title: string;
   content: string;
@@ -9,7 +12,8 @@ export type Room = {
 };
 
 export type RoomDetail = Room & {
-  participants: RoomParticipant[];
+  hostParticipants: RoomParticipant[];
+  guestParticipants: RoomParticipant[];
 };
 
 export type RoomParticipant = {
@@ -17,7 +21,7 @@ export type RoomParticipant = {
   nickname: string;
   studentId: string;
   gender: 'MALE' | 'FEMALE';
-  department: string;
+  major: string;
   isHost: boolean;
 };
 

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import { useStack } from '@stackflow/react';
+import { useSetAtom } from 'jotai';
 
 import { useFlow } from '@/app/stackflow';
-import { useStack } from '@stackflow/react';
-import { DOCK, DOCK_ITEMS } from '@/shared/constants';
+
+import { DOCK, DOCK_ITEMS, PATH } from '@/shared/constants';
 import { DockItem, PathItem } from '@/shared/types';
+import { fetchLoginStatus } from '@/shared/utils';
+import { bottomSheetAtom } from '@/shared/atom';
 
 interface DockButtonProps {
   item: DockItem;
@@ -17,7 +21,8 @@ export default function Dock() {
     .filter(i => i.transitionState === 'enter-done')
     .map(i => i.name)
     .pop() as PathItem;
-  const render = current === 'HomeScreen' || current === 'UserScreen';
+  const render = current === PATH.HOME || current === PATH.USER;
+
   return (
     <>
       {render && (
@@ -33,8 +38,12 @@ export default function Dock() {
 
 const DockButton = ({ item, selected }: DockButtonProps) => {
   const { replace } = useFlow();
+  const isLogin = fetchLoginStatus();
+  const setIsOpen = useSetAtom(bottomSheetAtom);
+
   const onClick = () => {
-    replace(item, { animate: false }, { animate: false });
+    if (item === PATH.USER && !isLogin) setIsOpen(true);
+    else replace(item, { animate: false }, { animate: false });
   };
 
   return (

--- a/src/shared/ui/GroupCarousel.tsx
+++ b/src/shared/ui/GroupCarousel.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useSetAtom } from 'jotai';
 
 import { useFlow } from '@/app/stackflow';
-
 import { Button, Card, CardSkeleton } from '@/shared/ui';
 import { PathItem, RoomListItem } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { REQUEST, useRoomList } from '@/shared/api';
+import { bottomSheetAtom } from '@/shared/atom';
+
 import { COVERED_ROOM_DATA } from '@/mock';
 import { Error } from '@/assets/images';
 
@@ -82,6 +84,8 @@ export default function GroupCarousel({
 }
 
 const CoveredMockup = () => {
+  const setIsOpen = useSetAtom(bottomSheetAtom);
+
   return (
     <div className='flex w-full flex-col gap-y-3'>
       <div className='scrollbar-hide h-card-height rounded-10 relative flex items-center gap-x-3 overflow-hidden'>
@@ -98,7 +102,7 @@ const CoveredMockup = () => {
             <Button
               name='next-step'
               size='sm'
-              onClick={() => {}}
+              onClick={() => setIsOpen(true)}
               label='로그인 하러가기'
             />
           </div>

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -49,7 +49,7 @@ export default function Input({
       {maxLength && typeof value === 'string' && (
         <div
           className={cn(
-            'text-light flex justify-end',
+            'text-light flex justify-end text-sm',
             enableMaxLengthEffect && 'text-important',
           )}
         >

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -40,7 +40,8 @@ export default function Input({
           enableMaxLengthEffect && 'shake border-important',
         )}
         placeholder={placeholder}
-        type={type}
+        type={type === 'number' ? 'text' : type}
+        inputMode={type === 'number' ? 'numeric' : undefined}
         value={value}
         onChange={onChange}
         disabled={disabled}

--- a/src/shared/ui/LoginBottomSheet.tsx
+++ b/src/shared/ui/LoginBottomSheet.tsx
@@ -1,26 +1,24 @@
-import React, { useState, useEffect, Dispatch, SetStateAction } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useAtom } from 'jotai';
 
 import { cn } from '@/shared/utils';
 import { Button } from '@/shared/ui';
 import { KakaoIcon } from '@/assets/icons';
+import { bottomSheetAtom } from '@/shared/atom';
 
-interface LoginBottomSheetProps {
-  isOpen: boolean;
-  onClose: () => void;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
-}
-
-export default function LoginBottomSheet({
-  isOpen,
-  onClose,
-  setIsOpen,
-}: LoginBottomSheetProps) {
+export default function LoginBottomSheet() {
   const [visible, setVisible] = useState(false);
+  const [isOpen, setIsOpen] = useAtom(bottomSheetAtom);
 
   const handleClick = () => {
     setIsOpen(false);
     setVisible(false);
     window.location.href = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_REDIRECT_URL}`;
+  };
+
+  const onClose = () => {
+    setIsOpen(false);
+    setVisible(false);
   };
 
   useEffect(() => {

--- a/src/widgets/create/api/create.ts
+++ b/src/widgets/create/api/create.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { REQUEST } from '@/shared/api';
+import { userPost } from '@/shared/api/user';
+import { Room } from '@/shared/types';
+
+import { useRoomCreateContext } from '@/widgets/create/model';
+
+const submitRoomCreation = async (data: Room) => {
+  await userPost<Room>({
+    request: REQUEST.ROOM,
+    data: data,
+  });
+};
+
+export const useFormSubmit = () => {
+  const { setMode } = useRoomCreateContext();
+
+  return useMutation<unknown, unknown, Room>({
+    mutationFn: data => submitRoomCreation(data),
+    onSuccess: () => setMode(prev => prev + 1),
+    onError: () => alert('모임방 생성에 실패했어요.'),
+  });
+};

--- a/src/widgets/create/api/index.ts
+++ b/src/widgets/create/api/index.ts
@@ -1,0 +1,1 @@
+export * from './create';

--- a/src/widgets/create/model/constants/form.ts
+++ b/src/widgets/create/model/constants/form.ts
@@ -5,7 +5,7 @@ export const DETAIL_OPTION = {
     { id: 'people-6', value: 6, label: '6명 (3:3)' },
   ] as const,
   preferredGender: [
-    { id: 'male', value: '남성', label: '남자' },
-    { id: 'female', value: '여성', label: '여자' },
+    { id: 'male', value: 'MALE', label: '남자' } as const,
+    { id: 'female', value: 'FEMALE', label: '여자' } as const,
   ],
 };

--- a/src/widgets/create/model/constants/room.ts
+++ b/src/widgets/create/model/constants/room.ts
@@ -1,3 +1,4 @@
 export const TITLE_MIN_LENGTH = 5;
 export const TITLE_MAX_LENGTH = 20;
+export const PLACE_MAX_LENGTH = 10;
 export const CONTENT_MAX_LENGTH = 200;

--- a/src/widgets/create/model/contexts/create.ts
+++ b/src/widgets/create/model/contexts/create.ts
@@ -1,0 +1,12 @@
+import { createContext, type Dispatch, type SetStateAction } from 'react';
+
+export const RoomCreateContext = createContext<{
+  mode: number;
+  setMode: Dispatch<SetStateAction<number>>;
+  headCountRender: number;
+  setHeadCountRender: Dispatch<SetStateAction<number>>;
+  file: File | undefined;
+  setFile: Dispatch<SetStateAction<File | undefined>>;
+  image: string;
+  setImage: Dispatch<SetStateAction<string>>;
+} | null>(null);

--- a/src/widgets/create/model/contexts/index.ts
+++ b/src/widgets/create/model/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './create';

--- a/src/widgets/create/model/hooks/index.ts
+++ b/src/widgets/create/model/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useRoomCreateContext } from './useRoomCreateContext';
+export { default as useFormMode } from './useFormMode';

--- a/src/widgets/create/model/hooks/useFormMode.tsx
+++ b/src/widgets/create/model/hooks/useFormMode.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import type {
+  UseFormSetValue,
+  UseFormWatch,
+  UseFormRegister,
+} from 'react-hook-form';
+
+import { Room } from '@/shared/types';
+
+import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
+import {
+  CONTENT_MAX_LENGTH,
+  TITLE_MAX_LENGTH,
+  TITLE_MIN_LENGTH,
+} from '@/widgets/create/model';
+
+interface RoomModeProps {
+  register: UseFormRegister<Room>;
+  watch: UseFormWatch<Room>;
+  setValue: UseFormSetValue<Room>;
+}
+
+export default function useFormMode({
+  register,
+  watch,
+  setValue,
+}: RoomModeProps) {
+  const { title, content, preferredGender, headCount, place } = watch();
+
+  const MODE = [
+    {
+      title: '모임방 기본 정보',
+      form: <GroupTitleForm register={register} watch={watch} />,
+      button: '다음으로',
+      isFormValid:
+        title?.length >= TITLE_MIN_LENGTH &&
+        content.length > 0 &&
+        title?.length <= TITLE_MAX_LENGTH &&
+        content.length <= CONTENT_MAX_LENGTH &&
+        place?.length > 0,
+    },
+    {
+      title: '모임방 세부 정보',
+      form: (
+        <GroupDetailForm
+          register={register}
+          watch={watch}
+          setValue={setValue}
+        />
+      ),
+      button: '생성하기',
+      isFormValid: preferredGender && headCount,
+    },
+  ];
+
+  return { MODE: [...MODE] };
+}

--- a/src/widgets/create/model/hooks/useRoomCreateContext.ts
+++ b/src/widgets/create/model/hooks/useRoomCreateContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { RoomCreateContext } from '@/widgets/create/model';
+
+export default function useRoomCreateContext() {
+  const context = useContext(RoomCreateContext);
+  if (!context) {
+    throw new Error(
+      'useRoomCreateContext는 CreateProvider 안에서만 사용할 수 있어요.',
+    );
+  }
+  return context;
+}

--- a/src/widgets/create/model/index.ts
+++ b/src/widgets/create/model/index.ts
@@ -1,1 +1,4 @@
 export * from './constants';
+export * from './contexts';
+export * from './providers';
+export * from './hooks';

--- a/src/widgets/create/model/providers/create.tsx
+++ b/src/widgets/create/model/providers/create.tsx
@@ -1,0 +1,27 @@
+import React, { useState, type ReactNode } from 'react';
+
+import { RoomCreateContext } from '@/widgets/create/model';
+
+export default function CreateProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState(0);
+  const [headCountRender, setHeadCountRender] = useState(2);
+  const [file, setFile] = useState<File | undefined>(undefined);
+  const [image, setImage] = useState<string>('');
+
+  return (
+    <RoomCreateContext.Provider
+      value={{
+        mode,
+        setMode,
+        headCountRender,
+        setHeadCountRender,
+        file,
+        setFile,
+        image,
+        setImage,
+      }}
+    >
+      {children}
+    </RoomCreateContext.Provider>
+  );
+}

--- a/src/widgets/create/model/providers/index.ts
+++ b/src/widgets/create/model/providers/index.ts
@@ -1,0 +1,1 @@
+export { default as CreateProvider } from './create';

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 
 import { useForm } from 'react-hook-form';
 
-import { cn, getCookie, getDate } from '@/shared/utils';
-import { post, REQUEST } from '@/shared/api';
+import { cn, getDate } from '@/shared/utils';
 import { Button } from '@/shared/ui';
 
 import {
@@ -16,43 +15,54 @@ import { Room } from '@/shared/types';
 
 export default function CreateContainer() {
   const [mode, setMode] = useState(0);
+  const [headCountRender, setHeadCountRender] = useState(2);
+  const [file, setFile] = useState<File | undefined>(undefined);
+
   const { register, watch, setValue } = useForm<Room>({
     defaultValues: {
       content: '',
+      preferredStudentIdMin: '25',
+      preferredStudentIdMax: '24',
       meetingDateTime: getDate(new Date(), 'YYYY-MM-DD HH:MM:') + '00',
     },
   });
 
-  const { title, content, preferredGender, headCount } = watch();
+  const { title, content, preferredGender, headCount, place } = watch();
   const handleSubmit = async () => {
     const postData = {
       ...watch(),
       headCount: Number(watch('headCount')) as 2 | 4 | 6,
     };
-    const token = getCookie();
-    console.log(postData);
-    await post<Room>({
-      request: REQUEST.ROOM,
-      data: postData,
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const formData = new FormData();
+    formData.append('imageFiles', file!);
+    console.log({ ...postData, ...formData });
+    // await post<Room>({
+    //   request: REQUEST.ROOM,
+    //   data: { ...postData, ...formData },
+    //   headers: { Authorization: `Bearer ${token}` },
+    // });
   };
 
   const MODE = [
     {
-      title: '1. 모임방 이름, 설명',
-      form: <GroupTitleForm register={register} watch={watch} />,
+      title: '모임방 기본 정보',
+      form: (
+        <GroupTitleForm register={register} watch={watch} setFile={setFile} />
+      ),
       button: '다음으로',
       isFormValid:
         title?.length >= TITLE_MIN_LENGTH &&
         content.length > 0 &&
-        title?.length < TITLE_MAX_LENGTH &&
-        content.length < CONTENT_MAX_LENGTH,
+        title?.length <= TITLE_MAX_LENGTH &&
+        content.length <= CONTENT_MAX_LENGTH &&
+        place?.length > 0,
     },
     {
-      title: '2. 모임방 세부 정보',
+      title: '모임방 세부 정보',
       form: (
         <GroupDetailForm
+          headCountRender={headCountRender}
+          setHeadCountRender={setHeadCountRender}
           register={register}
           watch={watch}
           setValue={setValue}

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -1,22 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useForm } from 'react-hook-form';
 
 import { cn, getDate } from '@/shared/utils';
 import { Button } from '@/shared/ui';
 
-import {
-  CONTENT_MAX_LENGTH,
-  TITLE_MAX_LENGTH,
-  TITLE_MIN_LENGTH,
-} from '@/widgets/create/model';
-import { GroupDetailForm, GroupTitleForm } from '@/widgets/create/ui';
+import { useRoomCreateContext, useRoomMode } from '@/widgets/create/model';
 import { Room } from '@/shared/types';
 
 export default function CreateContainer() {
-  const [mode, setMode] = useState(0);
-  const [headCountRender, setHeadCountRender] = useState(2);
-  const [file, setFile] = useState<File | undefined>(undefined);
+  const { mode, setMode, file } = useRoomCreateContext();
 
   const { register, watch, setValue } = useForm<Room>({
     defaultValues: {
@@ -27,7 +20,9 @@ export default function CreateContainer() {
     },
   });
 
-  const { title, content, preferredGender, headCount, place } = watch();
+  const { MODE } = useRoomMode({ register, watch, setValue });
+  const { form, isFormValid, button } = MODE[mode];
+
   const handleSubmit = async () => {
     const postData = {
       ...watch(),
@@ -42,38 +37,6 @@ export default function CreateContainer() {
     //   headers: { Authorization: `Bearer ${token}` },
     // });
   };
-
-  const MODE = [
-    {
-      title: '모임방 기본 정보',
-      form: (
-        <GroupTitleForm register={register} watch={watch} setFile={setFile} />
-      ),
-      button: '다음으로',
-      isFormValid:
-        title?.length >= TITLE_MIN_LENGTH &&
-        content.length > 0 &&
-        title?.length <= TITLE_MAX_LENGTH &&
-        content.length <= CONTENT_MAX_LENGTH &&
-        place?.length > 0,
-    },
-    {
-      title: '모임방 세부 정보',
-      form: (
-        <GroupDetailForm
-          headCountRender={headCountRender}
-          setHeadCountRender={setHeadCountRender}
-          register={register}
-          watch={watch}
-          setValue={setValue}
-        />
-      ),
-      button: '생성하기',
-      isFormValid: preferredGender && headCount,
-    },
-  ];
-
-  const { form, isFormValid, button } = MODE[mode];
 
   return (
     <form className='flex size-full flex-col justify-between'>
@@ -101,7 +64,7 @@ export default function CreateContainer() {
       <Button
         name='group-form-submit'
         type='button'
-        className='disabled:bg-sub disabled:text-border box-shadow-buttonLg rounded-10 hover:bg-primary-hover mb-normal-spacing bg-point z-30 h-16 w-full flex-shrink-0 cursor-pointer text-lg font-semibold text-white transition duration-300'
+        size='lg'
         disabled={!isFormValid}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/shared/ui';
 
 import { useRoomCreateContext, useFormMode } from '@/widgets/create/model';
 import { Room } from '@/shared/types';
+import { useFormSubmit } from '@/widgets/create/api';
 
 export default function CreateContainer() {
   const { mode, setMode, file } = useRoomCreateContext();
@@ -22,20 +23,17 @@ export default function CreateContainer() {
 
   const { MODE } = useFormMode({ register, watch, setValue });
   const { form, isFormValid, button } = MODE[mode];
+  const { mutate, isPending } = useFormSubmit();
 
   const handleSubmit = async () => {
+    const formData = new FormData();
+    formData.append('imageFiles', file!);
     const postData = {
       ...watch(),
       headCount: Number(watch('headCount')) as 2 | 4 | 6,
+      ...formData,
     };
-    const formData = new FormData();
-    formData.append('imageFiles', file!);
-    console.log({ ...postData, ...formData });
-    // await post<Room>({
-    //   request: REQUEST.ROOM,
-    //   data: { ...postData, ...formData },
-    //   headers: { Authorization: `Bearer ${token}` },
-    // });
+    mutate({ ...postData });
   };
 
   return (
@@ -65,13 +63,13 @@ export default function CreateContainer() {
         name='group-form-submit'
         type='button'
         size='lg'
-        disabled={!isFormValid}
+        disabled={!isFormValid || isPending}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();
-          if (mode === 0) setMode(prev => (prev === 0 ? 1 : 1));
+          if (mode === 0) setMode(1);
           else handleSubmit();
         }}
-        label={button}
+        label={isPending ? '방을 만드는 중..' : button}
       />
     </form>
   );

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { cn, getDate } from '@/shared/utils';
 import { Button } from '@/shared/ui';
 
-import { useRoomCreateContext, useRoomMode } from '@/widgets/create/model';
+import { useRoomCreateContext, useFormMode } from '@/widgets/create/model';
 import { Room } from '@/shared/types';
 
 export default function CreateContainer() {
@@ -20,7 +20,7 @@ export default function CreateContainer() {
     },
   });
 
-  const { MODE } = useRoomMode({ register, watch, setValue });
+  const { MODE } = useFormMode({ register, watch, setValue });
   const { form, isFormValid, button } = MODE[mode];
 
   const handleSubmit = async () => {

--- a/src/widgets/create/ui/GroupDetailForm.tsx
+++ b/src/widgets/create/ui/GroupDetailForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 import {
   UseFormSetValue,
@@ -15,18 +15,48 @@ interface GroupTitleFormProps {
   register: UseFormRegister<Room>;
   watch: UseFormWatch<Room>;
   setValue: UseFormSetValue<Room>;
+  setHeadCountRender: Dispatch<SetStateAction<number>>;
+  headCountRender: number;
 }
 
 export default function GroupDetailForm({
   register,
   watch,
   setValue,
+  setHeadCountRender,
+  headCountRender,
 }: GroupTitleFormProps) {
-  const { preferredGender, headCount, meetingDateTime } = watch();
-  const [headCountRender, setHeadCountRender] = useState(2);
-
+  const {
+    preferredGender,
+    headCount,
+    meetingDateTime,
+    preferredStudentIdMin,
+    preferredStudentIdMax,
+  } = watch();
   return (
     <>
+      <FormItem
+        title='희망 멤버 학번'
+        description='모임방에 들어올 구성원들의 학번을 지정해주세요.'
+      >
+        <div className='flex w-full items-center gap-2'>
+          <Input
+            className='w-14'
+            type='number'
+            id='preferredStudentIdMin'
+            value={preferredStudentIdMin.slice(0, 2)}
+            {...register('preferredStudentIdMin', { required: true })}
+          />
+          이상
+          <Input
+            className='w-14'
+            id='preferredStudentIdMax'
+            value={preferredStudentIdMax.slice(0, 2)}
+            {...register('preferredStudentIdMax', { required: true })}
+          />
+          이하
+        </div>
+      </FormItem>
       <FormItem
         title='성별 선택'
         description='모임방에 들어올 구성원들의 성별을 선택해주세요.'

--- a/src/widgets/create/ui/GroupDetailForm.tsx
+++ b/src/widgets/create/ui/GroupDetailForm.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
 import {
   UseFormSetValue,
@@ -8,23 +8,19 @@ import {
 
 import { FormItem, Input, Radio } from '@/shared/ui';
 import { Room } from '@/shared/types';
-import { DETAIL_OPTION } from '../model';
 import { getDate } from '@/shared/utils';
+import { DETAIL_OPTION, useRoomCreateContext } from '@/widgets/create/model';
 
 interface GroupTitleFormProps {
   register: UseFormRegister<Room>;
   watch: UseFormWatch<Room>;
   setValue: UseFormSetValue<Room>;
-  setHeadCountRender: Dispatch<SetStateAction<number>>;
-  headCountRender: number;
 }
 
 export default function GroupDetailForm({
   register,
   watch,
   setValue,
-  setHeadCountRender,
-  headCountRender,
 }: GroupTitleFormProps) {
   const {
     preferredGender,
@@ -33,6 +29,8 @@ export default function GroupDetailForm({
     preferredStudentIdMin,
     preferredStudentIdMax,
   } = watch();
+  const { headCountRender, setHeadCountRender } = useRoomCreateContext();
+
   return (
     <>
       <FormItem
@@ -50,6 +48,7 @@ export default function GroupDetailForm({
           이상
           <Input
             className='w-14'
+            type='number'
             id='preferredStudentIdMax'
             value={preferredStudentIdMax.slice(0, 2)}
             {...register('preferredStudentIdMax', { required: true })}

--- a/src/widgets/create/ui/GroupTitleForm.tsx
+++ b/src/widgets/create/ui/GroupTitleForm.tsx
@@ -1,56 +1,110 @@
-import React from 'react';
+import React, { ChangeEvent, useState } from 'react';
+import { type UseFormWatch, type UseFormRegister } from 'react-hook-form';
 
 import { cn } from '@/shared/utils';
 
 import { FormItem, Input } from '@/shared/ui';
-import { type UseFormWatch, type UseFormRegister } from 'react-hook-form';
 import { Room } from '@/shared/types';
-import { CONTENT_MAX_LENGTH, TITLE_MAX_LENGTH } from '../model';
+import {
+  CONTENT_MAX_LENGTH,
+  PLACE_MAX_LENGTH,
+  TITLE_MAX_LENGTH,
+} from '@/widgets/create/model';
 
 interface GroupTitleFormProps {
   register: UseFormRegister<Room>;
   watch: UseFormWatch<Room>;
+  setFile: React.Dispatch<React.SetStateAction<File | undefined>>;
 }
 
 export default function GroupTitleForm({
   register,
   watch,
+  setFile,
 }: GroupTitleFormProps) {
-  const { title, content } = watch();
+  const { title, place, content } = watch();
+  const [image, setImage] = useState<string>('');
+
+  const handleImageInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setFile(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setImage('');
+      setFile(undefined);
+    }
+  };
 
   return (
-    <>
+    <div>
+      <FormItem
+        title='모임방 이미지'
+        description='모임방 표지가 될 이미지를 등록해주세요!'
+        className='mb-3'
+      >
+        <label htmlFor='file'>
+          <input
+            id='file'
+            type='file'
+            className='hidden'
+            accept='image/*'
+            onChange={handleImageInputChange}
+          />
+          <div
+            className='border-border rounded-5 grid h-20 w-40 place-items-center border-[1px] bg-cover bg-center'
+            style={{ backgroundImage: `url(${image ?? ''})` }}
+          >
+            {!image && (
+              <span className='text-light font-light'>이미지 추가하기</span>
+            )}
+          </div>
+        </label>
+      </FormItem>
       <FormItem
         title='모임방 이름'
         description='모임방 이름은 꼭 5자 이상으로 작성해주세요!'
       >
         <Input
           id='title'
-          placeholder='모임방에 대해 간단하게 설명해주세요. ex) 체대 주점 가실 분..'
+          placeholder='ex) 체대 주점 가실 분!'
           value={title}
           maxLength={TITLE_MAX_LENGTH}
           {...register('title', { required: true })}
         />
       </FormItem>
-      <FormItem title='모임방 설명'>
+      <FormItem title='만남 장소' description='간단하고 명확하게 작성해주세요!'>
+        <Input
+          id='place'
+          placeholder='ex) 종강 카페 앞, 도서관 앞'
+          value={place}
+          maxLength={PLACE_MAX_LENGTH}
+          {...register('place', { required: true })}
+        />
+      </FormItem>
+      <FormItem title='모임방 설명' className='mb-normal-spacing'>
         <textarea
           id='content'
           placeholder='설명을 입력해주세요.'
           {...register('content', { required: true })}
           className={cn(
-            'border-border rounded-5 text-md h-64 w-full resize-none border-[1px] px-4 py-3 focus:outline-none',
+            'border-border rounded-5 text-md h-44 w-full resize-none border-[1px] px-4 py-3 focus:outline-none',
             content.length > CONTENT_MAX_LENGTH && 'border-important shake',
           )}
         />
         <div
           className={cn(
-            'text-light flex justify-end',
+            'text-light flex justify-end text-sm',
             content.length > CONTENT_MAX_LENGTH && 'text-important',
           )}
         >
           {content.length}/{CONTENT_MAX_LENGTH}
         </div>
       </FormItem>
-    </>
+    </div>
   );
 }

--- a/src/widgets/create/ui/GroupTitleForm.tsx
+++ b/src/widgets/create/ui/GroupTitleForm.tsx
@@ -1,5 +1,5 @@
-import React, { ChangeEvent, useState } from 'react';
-import { type UseFormWatch, type UseFormRegister } from 'react-hook-form';
+import React, { ChangeEvent } from 'react';
+import type { UseFormWatch, UseFormRegister } from 'react-hook-form';
 
 import { cn } from '@/shared/utils';
 
@@ -9,21 +9,20 @@ import {
   CONTENT_MAX_LENGTH,
   PLACE_MAX_LENGTH,
   TITLE_MAX_LENGTH,
+  useRoomCreateContext,
 } from '@/widgets/create/model';
 
 interface GroupTitleFormProps {
   register: UseFormRegister<Room>;
   watch: UseFormWatch<Room>;
-  setFile: React.Dispatch<React.SetStateAction<File | undefined>>;
 }
 
 export default function GroupTitleForm({
   register,
   watch,
-  setFile,
 }: GroupTitleFormProps) {
+  const { setFile, image, setImage } = useRoomCreateContext();
   const { title, place, content } = watch();
-  const [image, setImage] = useState<string>('');
 
   const handleImageInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -41,10 +40,10 @@ export default function GroupTitleForm({
   };
 
   return (
-    <div>
+    <div className='flex flex-col gap-y-2'>
       <FormItem
-        title='모임방 이미지'
-        description='모임방 표지가 될 이미지를 등록해주세요!'
+        title='모임방 표지 사진'
+        description='사진을 등록하지 않으면 기본 이미지로 자동 설정됩니다.'
         className='mb-3'
       >
         <label htmlFor='file'>

--- a/src/widgets/home/ui/HomeContainer.tsx
+++ b/src/widgets/home/ui/HomeContainer.tsx
@@ -4,6 +4,7 @@ import { GroupCarousel, GroupList } from '@/shared/ui';
 import { PATH } from '@/shared/constants';
 import { REQUEST } from '@/shared/api';
 import { BoothInfoBg } from '@/assets/images';
+import { fetchLoginStatus } from '@/shared/utils';
 
 export default function HomeContainer() {
   return (
@@ -14,7 +15,7 @@ export default function HomeContainer() {
         key='openedGroup'
         to={PATH.LIST}
         request={REQUEST.ROOM}
-        covered
+        covered={!fetchLoginStatus()}
       />
       <GroupList
         label='개설된 모임방'

--- a/src/widgets/room/api/room.ts
+++ b/src/widgets/room/api/room.ts
@@ -1,18 +1,10 @@
 import { get, REQUEST } from '@/shared/api';
-import { Room, RoomParticipant } from '@/shared/types';
+import { RoomDetail } from '@/shared/types';
 import { getCookie } from '@/shared/utils';
 import { useQuery } from '@tanstack/react-query';
 
 interface FetchRoomResponse {
-  result: Room & {
-    participants: RoomParticipant[];
-    images: [
-      {
-        name: string;
-        url: string;
-      },
-    ];
-  };
+  result: RoomDetail;
 }
 
 export const fetchRoomDetail = async ({ roomId }: { roomId: number }) => {
@@ -26,6 +18,6 @@ export const fetchRoomDetail = async ({ roomId }: { roomId: number }) => {
 export const useRoomDetail = (roomId: number) => {
   return useQuery({
     queryKey: [`room + ${roomId}`],
-    queryFn: async () => fetchRoomDetail({ roomId }),
+    queryFn: () => fetchRoomDetail({ roomId }),
   });
 };

--- a/src/widgets/room/types/room.ts
+++ b/src/widgets/room/types/room.ts
@@ -14,6 +14,6 @@ export type RoomParticipant = {
   nickname: string;
   studentId: string;
   gender: 'MALE' | 'FEMALE';
-  department: string;
+  major: string;
   isHost: boolean;
 };

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -30,10 +30,10 @@ export default function RoomContainer(props: RoomListItem) {
         {!isLoading && data && (
           <>
             <FormItem title='모임을 연 멤버'>
-              {data?.participants.map(m => <UserItem {...m} key={m.id} />)}
+              {data?.hostParticipants.map(m => <UserItem {...m} key={m.id} />)}
             </FormItem>
             <FormItem title='모임에 참여한 멤버'>
-              {data?.participants.map(m => {
+              {data?.guestParticipants.map(m => {
                 if (!m.isHost) return <UserItem {...m} key={m.id} />;
               })}
             </FormItem>

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,14 +1,24 @@
 import React from 'react';
+import { useSetAtom } from 'jotai';
 
 import { Button, FormItem, ListItem } from '@/shared/ui';
 import { RoomListItem } from '@/shared/types';
 
 import { UserItem } from '@/widgets/room/ui';
 import { useRoomDetail } from '@/widgets/room/api';
+import { fetchLoginStatus } from '@/shared/utils';
+import { bottomSheetAtom } from '@/shared/atom';
 
 export default function RoomContainer(props: RoomListItem) {
   const { id, content } = props;
   const { data, isLoading } = useRoomDetail(id);
+  const setIsOpen = useSetAtom(bottomSheetAtom);
+  const isLogin = fetchLoginStatus();
+
+  const handleJoin = () => {
+    if (isLogin) console.log('참여하기 모달이 열립니다.');
+    else setIsOpen(true);
+  };
 
   return (
     <div className='flex size-full flex-col justify-between'>
@@ -42,11 +52,17 @@ export default function RoomContainer(props: RoomListItem) {
         <div className='h-normal-spacing' />
       </div>
       <div className='z-30 flex h-fit w-full gap-x-3 text-lg font-semibold text-white'>
-        <Button name='room-participate' label='참여하기' halfWidth />
+        <Button
+          name='room-participate'
+          label='참여하기'
+          halfWidth
+          onClick={handleJoin}
+        />
         <Button
           name='room-participate-with-friend'
           label='친구와 함께 참여하기'
           halfWidth
+          onClick={handleJoin}
         />
       </div>
     </div>

--- a/src/widgets/room/ui/UserItem.tsx
+++ b/src/widgets/room/ui/UserItem.tsx
@@ -8,7 +8,7 @@ export default function UserItem({
   nickname,
   studentId,
   gender,
-  department,
+  major,
 }: RoomParticipant) {
   const male = gender === 'MALE';
 
@@ -36,7 +36,7 @@ export default function UserItem({
           </span>
         </div>
         <div className='flex w-fit items-center gap-x-1'>
-          <span>{department}</span>·<span>{studentId}학번 재학생</span>
+          <span>{major}</span>·<span>{studentId}학번 재학생</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용

> 방 생성 기능을 전체 구현 완료하고 API도 연동 완료했습니다.
(이제 TimePicker와 DatePicker만 구현하면 됩니다 ㅠㅠ)
- 이외 미로그인 시 로그인을 권유하는 `BottomSheet`의 상태를 전역으로 올려 관리하도록 변경하였고, 이에 따라 로그인 컨디셔널 렌더링 구현을 완료했습니다.


### 스크린샷 (선택)

| 생성 1단계 | 생성 2단계 |
|--------------------------|--------------------------------------------|
| ![number input](https://github.com/user-attachments/assets/837f3f44-6142-40ee-8ed8-1c6e31e57eab) | ![text+numeric input](https://github.com/user-attachments/assets/0dff72ee-ad4b-4e3f-a2d4-d0cd94ec5aa9) |
