### PR TITLE
[FIX] : 뒤로가기 생성으로 인한 UI 에러 수정

### DIFF
--- a/src/screen/auth/api/auth.ts
+++ b/src/screen/auth/api/auth.ts
@@ -1,6 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
-import { useNavigate } from 'react-router-dom';
 
 import { post, REQUEST } from '@/shared/api';
 import { userAtom } from '@/shared/atom';
@@ -57,13 +56,12 @@ export const useKakaoToken = () => {
 
 export const useKakaoLogin = () => {
   const setUserAtom = useSetAtom(userAtom);
-  const navigate = useNavigate();
 
   return useMutation<KakaoLoginResponse, unknown, KakaoLoginRequest>({
     mutationFn: ({ kakaoAccessToken }) => submitKakaoLogin(kakaoAccessToken),
     onSuccess: data => {
       setUserAtom(data.result);
-      navigate(RAW_PATH.HOME);
+      window.history.replaceState(null, '', RAW_PATH.HOME);
     },
   });
 };

--- a/src/screen/auth/ui/AuthScreen.tsx
+++ b/src/screen/auth/ui/AuthScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useSetAtom } from 'jotai';
 
 import { useKakaoLogin, useKakaoToken } from '@/screen/auth/api';
@@ -8,7 +7,6 @@ import { KakaoAccessTokenAtom } from '@/shared/atom';
 import { RAW_PATH } from '@/shared/constants';
 
 export default function AuthScreen() {
-  const navigate = useNavigate();
   const setKakaoToken = useSetAtom(KakaoAccessTokenAtom);
 
   const params = new URLSearchParams(location.search);
@@ -26,9 +24,9 @@ export default function AuthScreen() {
       const kakaoAccessToken = data.result.kakaoAccessToken;
       setKakaoToken({ kakaoAccessToken });
       if (data.result.member) login({ kakaoAccessToken });
-      else navigate(RAW_PATH.SIGNUP);
+      else window.history.replaceState(null, '', RAW_PATH.SIGNUP);
     }
-  }, [isSuccess, data, navigate, login, setKakaoToken]);
+  }, [isSuccess, data, login, setKakaoToken]);
 
   return (
     <div className='container-mobile grid h-screen place-items-center'>
@@ -41,7 +39,10 @@ export default function AuthScreen() {
       {isError && (
         <div className='flex flex-col text-lg'>
           로그인에 실패했어요.
-          <button className='focus:outline-none' onClick={() => navigate('/')}>
+          <button
+            className='focus:outline-none'
+            onClick={() => window.history.replaceState(null, '', RAW_PATH.HOME)}
+          >
             홈으로 돌아가기
           </button>
         </div>

--- a/src/widgets/signup/ui/SignupComplete.tsx
+++ b/src/widgets/signup/ui/SignupComplete.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
-import { useFlow } from '@/app/stackflow';
 import { SignupSuccessBg } from '@/assets/images';
 import { Button } from '@/shared/ui';
+import { RAW_PATH } from '@/shared/constants';
 
 export default function SignupComplete() {
-  const { pop } = useFlow();
-  const handleHomeClick = () => pop();
+  const handleHomeClick = () =>
+    window.history.replaceState(null, '', RAW_PATH.HOME);
 
   return (
     <div
-      className='grid size-full place-items-center bg-cover bg-center'
+      className='grid h-screen w-full place-items-center bg-cover bg-center'
       style={{ backgroundImage: `url(${SignupSuccessBg})` }}
     >
       <div className='flex w-[80%] flex-col items-start gap-2'>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #36 

## 📝 작업 내용

> 히스토리 스택에 새 항목을 추가하지 않고 페이지를 전환할 수 있도록 변경했어요.
- 해당 조치를 통해 온전한 `StackFlow` 애플리케이션, 원활한 카카오 로그인과 회원가입 처리를 구현할 수 있어요.
- 네이티브 앱과 같은 기능을 제공할 수 있어요.

