### PR TITLE
[FEAT] : 바텀시트 컴포넌트 분리, 모임방 세부페이지 UI 변경

### DIFF
--- a/src/screen/home/ui/HomeScreen.tsx
+++ b/src/screen/home/ui/HomeScreen.tsx
@@ -3,23 +3,24 @@ import React from 'react';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { MdAdd } from 'react-icons/md';
 
-import { AppBar, Button, Dock, LoginBottomSheet } from '@/shared/ui';
-import { HomeContainer } from '@/widgets/home/ui';
 import { useFlow } from '@/app/stackflow';
-import { PATH } from '@/shared/constants';
+
+import { AppBar, Button, Dock, LoginBottomSheet } from '@/shared/ui';
+import { BOTTOM_SHEET, PATH } from '@/shared/constants';
 import { fetchLoginStatus } from '@/shared/utils';
-import { useSetAtom } from 'jotai';
-import { bottomSheetAtom } from '@/shared/atom';
+import { useBottomSheet } from '@/shared/hook';
+
+import { HomeContainer } from '@/widgets/home/ui';
 
 export default function HomeScreen() {
-  const hasToken = fetchLoginStatus();
-  const setIsOpen = useSetAtom(bottomSheetAtom);
+  const { openBottomSheet } = useBottomSheet();
   const { replace, push } = useFlow();
+  const isLogin = fetchLoginStatus();
 
   const searchOnClick = () => replace(PATH.SEARCH, {});
   const createOnClick = () => {
-    if (hasToken) push(PATH.CREATE, {});
-    else setIsOpen(true);
+    if (isLogin) push(PATH.CREATE, {});
+    else openBottomSheet(BOTTOM_SHEET.LOGIN);
   };
 
   return (

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -1,20 +1,28 @@
 import { ActivityComponentType } from '@stackflow/react';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { NormalAppBar } from '@/shared/ui';
-import { RoomContainer } from '@/widgets/room/ui';
+import { RoomAppBar } from '@/shared/ui';
+import { MenuBottomSheet, RoomContainer } from '@/widgets/room/ui';
 import { RoomListItem } from '@/shared/types';
+import { useBottomSheet } from '@/shared/hook';
+import { BOTTOM_SHEET } from '@/shared/constants';
 
 const RoomScreen: ActivityComponentType<RoomListItem> = ({
   params,
 }: {
   params: RoomListItem;
 }) => {
+  const { openBottomSheet } = useBottomSheet();
+  const handleMenuClick = () => openBottomSheet(BOTTOM_SHEET.MENU);
+
   return (
-    <AppScreen appBar={NormalAppBar('모임방 상세')}>
-      <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding flex size-full flex-col overflow-scroll overflow-y-scroll'>
-        <RoomContainer {...params} />
-      </div>
-    </AppScreen>
+    <>
+      <AppScreen appBar={RoomAppBar(handleMenuClick)}>
+        <div className='scrollbar-hide container-mobile gap-y-normal-spacing p-normal-padding flex size-full flex-col overflow-scroll overflow-y-scroll'>
+          <RoomContainer {...params} />
+        </div>
+      </AppScreen>
+      <MenuBottomSheet />
+    </>
   );
 };
 

--- a/src/shared/atom/bottomSheet.ts
+++ b/src/shared/atom/bottomSheet.ts
@@ -4,22 +4,29 @@ import type { BottomSheetItem } from '../types';
 import { BOTTOM_SHEET } from '../constants';
 
 type BottomSheetInfo = {
-  [key in BottomSheetItem]: { isOpen: boolean };
+  [key in BottomSheetItem]: { isOpen: boolean; isVisible: boolean };
 };
 
 const bottomSheet = Object.fromEntries(
-  Object.keys(BOTTOM_SHEET).map(key => [key, { isOpen: false }]),
+  Object.keys(BOTTOM_SHEET).map(key => [
+    key,
+    { isOpen: false, isVisible: false },
+  ]),
 ) as BottomSheetInfo;
 
 export const bottomSheetAtom = atom<BottomSheetInfo>(bottomSheet);
 
 export const updateBottomSheet = atom(
   null,
-  (get, set, update: { key: BottomSheetItem; isOpen: boolean }) => {
+  (
+    get,
+    set,
+    update: { key: BottomSheetItem; isOpen: boolean; isVisible: boolean },
+  ) => {
     const currentBottomSheet = get(bottomSheetAtom);
     const updatedBottomSheet = {
       ...currentBottomSheet,
-      [update.key]: { isOpen: update.isOpen },
+      [update.key]: { isOpen: update.isOpen, isVisible: update.isVisible },
     };
     set(bottomSheetAtom, updatedBottomSheet);
   },

--- a/src/shared/atom/bottomSheet.ts
+++ b/src/shared/atom/bottomSheet.ts
@@ -1,3 +1,26 @@
 import { atom } from 'jotai';
 
-export const bottomSheetAtom = atom(false);
+import type { BottomSheetItem } from '../types';
+import { BOTTOM_SHEET } from '../constants';
+
+type BottomSheetInfo = {
+  [key in BottomSheetItem]: { isOpen: boolean };
+};
+
+const bottomSheet = Object.fromEntries(
+  Object.keys(BOTTOM_SHEET).map(key => [key, { isOpen: false }]),
+) as BottomSheetInfo;
+
+export const bottomSheetAtom = atom<BottomSheetInfo>(bottomSheet);
+
+export const updateBottomSheet = atom(
+  null,
+  (get, set, update: { key: BottomSheetItem; isOpen: boolean }) => {
+    const currentBottomSheet = get(bottomSheetAtom);
+    const updatedBottomSheet = {
+      ...currentBottomSheet,
+      [update.key]: { isOpen: update.isOpen },
+    };
+    set(bottomSheetAtom, updatedBottomSheet);
+  },
+);

--- a/src/shared/constants/bottomSheet.ts
+++ b/src/shared/constants/bottomSheet.ts
@@ -1,0 +1,4 @@
+export const BOTTOM_SHEET = {
+  LOGIN: 'login',
+  MENU: 'menu',
+} as const;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './dock';
 export * from './path';
 export * from './gender';
+export * from './bottomSheet';

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -2,3 +2,4 @@ export * from './dock';
 export * from './path';
 export * from './gender';
 export * from './bottomSheet';
+export * from './status';

--- a/src/shared/constants/status.ts
+++ b/src/shared/constants/status.ts
@@ -1,0 +1,5 @@
+export const ROOM_STATUS: Record<string, string> = {
+  MATCHING: '매칭중',
+  MATCHED: '매칭완료',
+  CLOSED: '종료',
+};

--- a/src/shared/hook/index.ts
+++ b/src/shared/hook/index.ts
@@ -1,0 +1,1 @@
+export { default as useBottomSheet } from './useBottomSheet';

--- a/src/shared/hook/useBottomSheet.ts
+++ b/src/shared/hook/useBottomSheet.ts
@@ -9,10 +9,24 @@ export default function useBottomSheet() {
 
   const bottomSheetState = (key: BottomSheetItem) =>
     bottomSheet[key] || { isOpen: false };
-  const openBottomSheet = (key: BottomSheetItem) =>
-    setBottomSheet({ key, isOpen: true });
-  const closeBottomSheet = (key: BottomSheetItem) =>
-    setBottomSheet({ key, isOpen: false });
+  const openBottomSheet = (key: BottomSheetItem) => {
+    setBottomSheet({ key, isOpen: true, isVisible: false });
+    setTimeout(
+      () => setBottomSheet({ key, isOpen: true, isVisible: true }),
+      100,
+    );
+  };
+  const closeBottomSheet = (key: BottomSheetItem) => {
+    setBottomSheet({ key, isOpen: true, isVisible: false });
+    setTimeout(
+      () => setBottomSheet({ key, isOpen: false, isVisible: false }),
+      300,
+    );
+  };
 
-  return { bottomSheetState, openBottomSheet, closeBottomSheet };
+  return {
+    bottomSheetState,
+    openBottomSheet,
+    closeBottomSheet,
+  };
 }

--- a/src/shared/hook/useBottomSheet.ts
+++ b/src/shared/hook/useBottomSheet.ts
@@ -1,0 +1,18 @@
+import { useAtomValue, useSetAtom } from 'jotai';
+
+import { bottomSheetAtom, updateBottomSheet } from '../atom';
+import { BottomSheetItem } from '../types';
+
+export default function useBottomSheet() {
+  const bottomSheet = useAtomValue(bottomSheetAtom);
+  const setBottomSheet = useSetAtom(updateBottomSheet);
+
+  const bottomSheetState = (key: BottomSheetItem) =>
+    bottomSheet[key] || { isOpen: false };
+  const openBottomSheet = (key: BottomSheetItem) =>
+    setBottomSheet({ key, isOpen: true });
+  const closeBottomSheet = (key: BottomSheetItem) =>
+    setBottomSheet({ key, isOpen: false });
+
+  return { bottomSheetState, openBottomSheet, closeBottomSheet };
+}

--- a/src/shared/types/bottomSheet.ts
+++ b/src/shared/types/bottomSheet.ts
@@ -1,0 +1,3 @@
+import { BOTTOM_SHEET } from '../constants';
+
+export type BottomSheetItem = (typeof BOTTOM_SHEET)[keyof typeof BOTTOM_SHEET];

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,3 +2,4 @@ export * from './dock';
 export * from './path';
 export * from './room';
 export * from './gender';
+export * from './bottomSheet';

--- a/src/shared/ui/AppBar.tsx
+++ b/src/shared/ui/AppBar.tsx
@@ -1,5 +1,6 @@
 import { FiSearch } from 'react-icons/fi';
 import { IoChevronBackSharp } from 'react-icons/io5';
+import { HiOutlineDotsVertical } from 'react-icons/hi';
 
 import Input from './Input';
 
@@ -45,4 +46,14 @@ export const SearchAppBar = (
   ),
   ...baseStyle,
   backgroundColor: '#fff',
+});
+
+export const RoomAppBar = (menuOnClick: () => void) => ({
+  renderRight: () => (
+    <button onClick={menuOnClick} name='menu'>
+      <HiOutlineDotsVertical size={22} />
+    </button>
+  ),
+  closeButton: { renderIcon: () => <></> },
+  ...baseStyle,
 });

--- a/src/shared/ui/BottomSheet.tsx
+++ b/src/shared/ui/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
 import { cn } from '@/shared/utils';
 import { BottomSheetItem } from '../types';
@@ -10,33 +10,21 @@ interface BottomSheetProps {
 }
 
 export default function BottomSheet({ children, sheetKey }: BottomSheetProps) {
-  const [visible, setVisible] = useState(false);
   const { closeBottomSheet, bottomSheetState } = useBottomSheet();
-  const { isOpen } = bottomSheetState(sheetKey);
-
-  const onClose = () => {
-    closeBottomSheet(sheetKey);
-    setVisible(false);
-  };
-
-  useEffect(() => {
-    if (isOpen) setVisible(true);
-    else {
-      setTimeout(() => setVisible(false), 300);
-    }
-  }, [isOpen]);
+  const { isVisible } = bottomSheetState(sheetKey);
+  const onClose = () => closeBottomSheet(sheetKey);
 
   return (
     <>
       <div
-        className={cn('overlay', visible && 'overlay-visible')}
+        className={cn('overlay', isVisible && 'overlay-visible')}
         onClick={onClose}
       />
       <div
         className={cn(
           'rounded-t-10 fixed bottom-0 left-0 z-400 flex h-60 h-fit w-full flex-col bg-white p-6 pt-8 pb-18 shadow-lg transition-transform duration-300',
-          isOpen ? 'translate-y-0' : 'translate-y-full',
-          visible ? 'box-shadow-bottom-sheet block' : 'none',
+          isVisible ? 'translate-y-0' : 'translate-y-full',
+          isVisible ? 'box-shadow-bottom-sheet block' : '',
         )}
       >
         {children}

--- a/src/shared/ui/BottomSheet.tsx
+++ b/src/shared/ui/BottomSheet.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect, ReactNode } from 'react';
+
+import { cn } from '@/shared/utils';
+import { BottomSheetItem } from '../types';
+import { useBottomSheet } from '../hook';
+
+interface BottomSheetProps {
+  children: ReactNode;
+  sheetKey: BottomSheetItem;
+}
+
+export default function BottomSheet({ children, sheetKey }: BottomSheetProps) {
+  const [visible, setVisible] = useState(false);
+  const { closeBottomSheet, bottomSheetState } = useBottomSheet();
+  const { isOpen } = bottomSheetState(sheetKey);
+
+  const onClose = () => {
+    closeBottomSheet(sheetKey);
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    if (isOpen) setVisible(true);
+    else {
+      setTimeout(() => setVisible(false), 300);
+    }
+  }, [isOpen]);
+
+  return (
+    <>
+      <div
+        className={cn('overlay', visible && 'overlay-visible')}
+        onClick={onClose}
+      />
+      <div
+        className={cn(
+          'rounded-t-10 fixed bottom-0 left-0 z-400 flex h-60 h-fit w-full flex-col bg-white p-6 pt-8 pb-18 shadow-lg transition-transform duration-300',
+          isOpen ? 'translate-y-0' : 'translate-y-full',
+          visible ? 'box-shadow-bottom-sheet block' : 'none',
+        )}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { useStack } from '@stackflow/react';
-import { useSetAtom } from 'jotai';
 
 import { useFlow } from '@/app/stackflow';
 
-import { DOCK, DOCK_ITEMS, PATH } from '@/shared/constants';
+import { BOTTOM_SHEET, DOCK, DOCK_ITEMS, PATH } from '@/shared/constants';
 import { DockItem, PathItem } from '@/shared/types';
 import { fetchLoginStatus } from '@/shared/utils';
-import { bottomSheetAtom } from '@/shared/atom';
+import { useBottomSheet } from '@/shared/hook';
 
 interface DockButtonProps {
   item: DockItem;
@@ -38,11 +37,11 @@ export default function Dock() {
 
 const DockButton = ({ item, selected }: DockButtonProps) => {
   const { replace } = useFlow();
+  const { openBottomSheet } = useBottomSheet();
   const isLogin = fetchLoginStatus();
-  const setIsOpen = useSetAtom(bottomSheetAtom);
 
   const onClick = () => {
-    if (item === PATH.USER && !isLogin) setIsOpen(true);
+    if (item === PATH.USER && !isLogin) openBottomSheet(BOTTOM_SHEET.LOGIN);
     else replace(item, { animate: false }, { animate: false });
   };
 

--- a/src/shared/ui/GroupCarousel.tsx
+++ b/src/shared/ui/GroupCarousel.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { useSetAtom } from 'jotai';
 
 import { useFlow } from '@/app/stackflow';
 import { Button, Card, CardSkeleton } from '@/shared/ui';
 import { PathItem, RoomListItem } from '@/shared/types';
 import { cn } from '@/shared/utils';
 import { REQUEST, useRoomList } from '@/shared/api';
-import { bottomSheetAtom } from '@/shared/atom';
 
 import { COVERED_ROOM_DATA } from '@/mock';
 import { Error } from '@/assets/images';
+import { useBottomSheet } from '../hook';
+import { BOTTOM_SHEET } from '../constants';
 
 interface GroupCarouselProps {
   label: string;
@@ -84,7 +84,7 @@ export default function GroupCarousel({
 }
 
 const CoveredMockup = () => {
-  const setIsOpen = useSetAtom(bottomSheetAtom);
+  const { openBottomSheet } = useBottomSheet();
 
   return (
     <div className='flex w-full flex-col gap-y-3'>
@@ -102,7 +102,7 @@ const CoveredMockup = () => {
             <Button
               name='next-step'
               size='sm'
-              onClick={() => setIsOpen(true)}
+              onClick={() => openBottomSheet(BOTTOM_SHEET.LOGIN)}
               label='로그인 하러가기'
             />
           </div>

--- a/src/shared/ui/LoginBottomSheet.tsx
+++ b/src/shared/ui/LoginBottomSheet.tsx
@@ -1,77 +1,51 @@
-import React, { useState, useEffect } from 'react';
-import { useAtom } from 'jotai';
+import React from 'react';
 
-import { cn } from '@/shared/utils';
-import { Button } from '@/shared/ui';
+import { BottomSheet, Button } from '@/shared/ui';
 import { KakaoIcon } from '@/assets/icons';
-import { bottomSheetAtom } from '@/shared/atom';
+import { BOTTOM_SHEET } from '../constants';
+import { useBottomSheet } from '../hook';
 
 export default function LoginBottomSheet() {
-  const [visible, setVisible] = useState(false);
-  const [isOpen, setIsOpen] = useAtom(bottomSheetAtom);
+  const { closeBottomSheet, bottomSheetState } = useBottomSheet();
+  const { isOpen } = bottomSheetState(BOTTOM_SHEET.LOGIN);
 
   const handleClick = () => {
-    setIsOpen(false);
-    setVisible(false);
+    closeBottomSheet(BOTTOM_SHEET.LOGIN);
     window.location.replace(
       `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_REDIRECT_URL}`,
     );
   };
 
-  const onClose = () => {
-    setIsOpen(false);
-    setVisible(false);
-  };
-
-  useEffect(() => {
-    if (isOpen) {
-      setVisible(true);
-    } else {
-      setTimeout(() => setVisible(false), 300);
-    }
-  }, [isOpen]);
-
   return (
     <>
       {isOpen && (
-        <div
-          className={cn('overlay', visible && 'overlay-visible')}
-          onClick={onClose}
-        />
+        <BottomSheet sheetKey={BOTTOM_SHEET.LOGIN}>
+          <div className='flex items-baseline justify-between'>
+            <span className='text-xl font-semibold'>
+              로그인이 필요한 기능이에요!
+            </span>
+            <button
+              className='text-md focus:outline-none'
+              name='close-bottom-sheet'
+              onClick={() => closeBottomSheet(BOTTOM_SHEET.LOGIN)}
+            >
+              닫기
+            </button>
+          </div>
+          <Button
+            onClick={handleClick}
+            size='md'
+            className='text-dark bg-kakao hover:bg-kakao mt-6 h-fit py-3 font-medium'
+            label={
+              <div className='flex w-full items-center justify-center gap-x-4 py-1'>
+                <img src={KakaoIcon} className='size-6' />
+                <span>카카오톡 간편 로그인</span>
+              </div>
+            }
+            shadow={false}
+          />
+        </BottomSheet>
       )}
-
-      <div
-        className={cn(
-          'rounded-t-10 fixed bottom-0 left-0 z-400 flex h-60 h-fit w-full flex-col bg-white p-6 pt-8 pb-18 shadow-lg transition-transform duration-300',
-          isOpen ? 'translate-y-0' : 'translate-y-full',
-          visible ? 'box-shadow-bottom-sheet block' : 'none',
-        )}
-      >
-        <div className='flex items-baseline justify-between'>
-          <span className='text-xl font-semibold'>
-            로그인이 필요한 기능이에요!
-          </span>
-          <button
-            className='text-md focus:outline-none'
-            name='close-bottom-sheet'
-            onClick={onClose}
-          >
-            닫기
-          </button>
-        </div>
-        <Button
-          onClick={handleClick}
-          size='md'
-          className='text-dark bg-kakao hover:bg-kakao mt-6 h-fit py-3 font-medium'
-          label={
-            <div className='flex w-full items-center justify-center gap-x-4 py-1'>
-              <img src={KakaoIcon} className='size-6' />
-              <span>카카오톡 간편 로그인</span>
-            </div>
-          }
-          shadow={false}
-        />
-      </div>
     </>
   );
 }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -11,5 +11,6 @@ export { default as GroupCarousel } from './GroupCarousel';
 export { default as GroupList } from './GroupList';
 export { default as Button } from './Button';
 export { default as LoginBottomSheet } from './LoginBottomSheet';
+export { default as BottomSheet } from './BottomSheet';
 
 export * from './AppBar';

--- a/src/widgets/room/ui/MenuBottomSheet.tsx
+++ b/src/widgets/room/ui/MenuBottomSheet.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { BottomSheet, Button } from '@/shared/ui';
+import { BOTTOM_SHEET } from '@/shared/constants';
+import { useBottomSheet } from '@/shared/hook';
+
+export default function MenuBottomSheet() {
+  const { closeBottomSheet, bottomSheetState } = useBottomSheet();
+  const { isOpen } = bottomSheetState(BOTTOM_SHEET.MENU);
+
+  return (
+    <>
+      {isOpen && (
+        <BottomSheet sheetKey={BOTTOM_SHEET.MENU}>
+          <div className='flex flex-col gap-3'>
+            <button className='w-full cursor-pointer py-1'>모임방 수정</button>
+            <button className='text-important w-full cursor-pointer py-1'>
+              모임방 신고
+            </button>
+          </div>
+          <Button
+            size='md'
+            className='text-dark bg-sub hover:bg-border mt-6 h-fit py-3 font-medium'
+            onClick={() => closeBottomSheet(BOTTOM_SHEET.MENU)}
+            label={
+              <div className='flex w-full items-center justify-center gap-x-4 py-1'>
+                <span>닫기</span>
+              </div>
+            }
+            shadow={false}
+          />
+        </BottomSheet>
+      )}
+    </>
+  );
+}

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { Button, FormItem, ListItem } from '@/shared/ui';
+import { Button, FormItem } from '@/shared/ui';
 import { RoomListItem } from '@/shared/types';
 
-import { UserItem } from '@/widgets/room/ui';
+import { RoomHeader, UserItem } from '@/widgets/room/ui';
 import { useRoomDetail } from '@/widgets/room/api';
 import { fetchLoginStatus } from '@/shared/utils';
 import { useBottomSheet } from '@/shared/hook';
@@ -23,8 +23,8 @@ export default function RoomContainer(props: RoomListItem) {
   return (
     <div className='flex size-full flex-col justify-between'>
       <div className='scrollbar-hide flex flex-col gap-y-6 overflow-scroll'>
-        <ListItem {...props} header />
-        <div className='border-sub flex h-fit w-full border-b-2 pb-6'>
+        <RoomHeader {...props} />
+        <div className='border-sub flex h-fit w-full border-y-1 py-6'>
           {content}
         </div>
         {isLoading && (
@@ -39,19 +39,29 @@ export default function RoomContainer(props: RoomListItem) {
         )}
         {!isLoading && data && (
           <>
-            <FormItem title='모임을 연 멤버'>
-              {data?.hostParticipants.map(m => <UserItem {...m} key={m.id} />)}
+            <FormItem
+              title='모임을 연 멤버'
+              className='border-sub border-b-1 pb-6'
+            >
+              {data.hostParticipants.map(m => (
+                <UserItem {...m} key={m.id} />
+              ))}
             </FormItem>
             <FormItem title='모임에 참여한 멤버'>
-              {data?.guestParticipants.map(m => {
+              {data.guestParticipants.map(m => {
                 if (!m.isHost) return <UserItem {...m} key={m.id} />;
               })}
+              {data.guestParticipants.length === 0 && (
+                <div className='text-light grid h-20 w-full place-items-center font-light'>
+                  아직 참여한 멤버가 없어요!
+                </div>
+              )}
             </FormItem>
           </>
         )}
         <div className='h-normal-spacing' />
       </div>
-      <div className='z-30 flex h-fit w-full gap-x-3 text-lg font-semibold text-white'>
+      <div className='border-t-app-bar-border z-30 flex h-fit w-full gap-x-3 border-[0.5px] pt-3 text-lg font-semibold text-white'>
         <Button
           name='room-participate'
           label='참여하기'

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSetAtom } from 'jotai';
 
 import { Button, FormItem, ListItem } from '@/shared/ui';
 import { RoomListItem } from '@/shared/types';
@@ -7,17 +6,18 @@ import { RoomListItem } from '@/shared/types';
 import { UserItem } from '@/widgets/room/ui';
 import { useRoomDetail } from '@/widgets/room/api';
 import { fetchLoginStatus } from '@/shared/utils';
-import { bottomSheetAtom } from '@/shared/atom';
+import { useBottomSheet } from '@/shared/hook';
+import { BOTTOM_SHEET } from '@/shared/constants';
 
 export default function RoomContainer(props: RoomListItem) {
   const { id, content } = props;
   const { data, isLoading } = useRoomDetail(id);
-  const setIsOpen = useSetAtom(bottomSheetAtom);
+  const { openBottomSheet } = useBottomSheet();
   const isLogin = fetchLoginStatus();
 
   const handleJoin = () => {
     if (isLogin) console.log('참여하기 모달이 열립니다.');
-    else setIsOpen(true);
+    else openBottomSheet(BOTTOM_SHEET.LOGIN);
   };
 
   return (

--- a/src/widgets/room/ui/RoomHeader.tsx
+++ b/src/widgets/room/ui/RoomHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { RoomListItem } from '@/shared/types';
+import { GENDER, ROOM_STATUS } from '@/shared/constants';
+import { GoClockFill } from 'react-icons/go';
+import { RiUser3Fill } from 'react-icons/ri';
+import { IoLocationSharp } from 'react-icons/io5';
+import { getDate } from '@/shared/utils';
+
+export default function RoomHeader(props: RoomListItem) {
+  const {
+    title,
+    thumbnail,
+    currentParticipants,
+    maxParticipants,
+    preferredGender,
+    meetingDateTime,
+    preferredStudentIdMin,
+    preferredStudentIdMax,
+    place,
+    status,
+  } = props;
+
+  return (
+    <>
+      <div className='rounded-10 relative flex h-fit w-full flex-col justify-end p-6'>
+        <div
+          className='bg-fill rounded-10 absolute inset-0 -z-1 h-full w-full bg-cover bg-center'
+          style={{ backgroundImage: `url(${thumbnail.url || ''})` }}
+        />
+        <div className='rounded-10 absolute inset-0 z-0 bg-black/50 bg-gradient-to-b from-transparent from-0% via-transparent via-50% to-black/60 to-100%' />
+        <div className='z-10 flex flex-col gap-1'>
+          <p className='items-start text-lg font-semibold text-white'>
+            {title}
+          </p>
+          <p className='flex items-center gap-2 text-sm text-white'>
+            <span className='border-border rounded-full border-1 bg-white/20 px-2 py-1'>
+              {GENDER[preferredGender]}
+            </span>
+            <span className='border-border rounded-full border-1 bg-white/20 px-2 py-1'>
+              {ROOM_STATUS[status]}
+            </span>
+          </p>
+        </div>
+      </div>
+      <div className='flex flex-col gap-1'>
+        <div className='flex items-center gap-1.5 text-start'>
+          <GoClockFill size={11} />
+          <span className='w-full overflow-hidden text-start'>
+            {getDate(meetingDateTime, 'M월 DD일 ddd요일 A h:mm')}
+          </span>
+        </div>
+        <p className='flex items-center gap-x-1.5'>
+          <RiUser3Fill size={12} /> {currentParticipants}명 / {maxParticipants}
+          명
+        </p>
+        <p className='flex items-center gap-x-1.5'>
+          <RiUser3Fill size={12} /> {preferredStudentIdMin}학번 ~{' '}
+          {preferredStudentIdMax}학번
+        </p>
+        <div className='flex items-center gap-1.5 text-start'>
+          <IoLocationSharp size={12} />
+          {place}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/widgets/room/ui/UserItem.tsx
+++ b/src/widgets/room/ui/UserItem.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { cn } from '@/shared/utils';
 
 import { RoomParticipant } from '@/widgets/room/types';
+import { IoMdFemale, IoMdMale } from 'react-icons/io';
 
 export default function UserItem({
   nickname,
@@ -23,17 +24,17 @@ export default function UserItem({
           }}
         />
       </div>
-      <div className='flex size-full flex-col gap-y-1'>
+      <div className='flex size-full flex-col'>
         <div className='flex w-fit items-center gap-x-2'>
-          <span className='text-lg font-semibold'>{nickname}</span>
           <span
             className={cn(
-              'rounded-5 grid w-fit place-items-center border-[0.5px] p-1 px-2 text-[10px]',
-              male ? 'border-male bg-male/20' : 'border-female bg-female/20',
+              'rounded-5 grid w-fit place-items-center',
+              male ? 'text-male' : 'text-female',
             )}
           >
-            {male ? '남성' : '여성'}
+            {male ? <IoMdMale size={16} /> : <IoMdFemale size={16} />}
           </span>
+          <span className='text-lg font-semibold'>{nickname}</span>
         </div>
         <div className='flex w-fit items-center gap-x-1'>
           <span>{major}</span>·<span>{studentId}학번 재학생</span>

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as RoomContainer } from './RoomContainer';
 export { default as UserItem } from './UserItem';
+export { default as MenuBottomSheet } from './MenuBottomSheet';

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -1,3 +1,4 @@
 export { default as RoomContainer } from './RoomContainer';
+export { default as RoomHeader } from './RoomHeader';
 export { default as UserItem } from './UserItem';
 export { default as MenuBottomSheet } from './MenuBottomSheet';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용

- 모임방 세부 페이지 내에서 바텀시트를 사용하기 위해 바텀시트를 공유 컴포넌트로 분리했어요.
- 바텀시트의 상태를 관리할 수 있는 `atom`을 생성하고, 애니메이션을 정상적으로 구현했어요.
- 모임방 상세 페이지의 UI가 변경되었어요. 
- 모임방 상세 페이지에서의 메뉴 바텀시트를 임시 구현했어요.
- 기존 회원가입 마지막 프로세스에서 발생하던 오류를 해결하기 위해 로직을 구조적으로 수정했어요. state와 `async/await` 방식의 `mutateAsync` 적용을 통해 정상적으로 작동할 수 있도록 수정했어요.

### 스크린샷 (선택)

<img width="344" alt="image" src="https://github.com/user-attachments/assets/2343dbf0-3813-4bef-b4be-ee5ef43bb685" />
<img width="344" alt="image" src="https://github.com/user-attachments/assets/5df983e2-6c12-419a-9c59-990570e4664b" />

