### PR TITLE
[FEAT] : 모임방 세부 화면 API 연동과 UI 디테일

### DIFF
--- a/src/mock/room.ts
+++ b/src/mock/room.ts
@@ -10,7 +10,7 @@ export const COVERED_ROOM_DATA = [
     content:
       '날씨 좋을 때 한강에서 돗자리 깔고 놀 사람 구해요! 간단한 간식이랑 음료는 제가 준비할게요 :)',
     place: '여의도 한강공원',
-    maxParticipants: 5,
+    maxParticipants: 4,
     currentParticipants: 2,
     thumbnail: {
       name: 'picnic.jpg',

--- a/src/screen/auth/api/auth.ts
+++ b/src/screen/auth/api/auth.ts
@@ -60,7 +60,7 @@ export const useKakaoToken = () => {
       if (data.result.member) mutate({ kakaoAccessToken });
       else
         window.location.replace(
-          `${getPath(import.meta.env.VITE_PRODUCTION_URL, RAW_PATH.SIGNUP)}`,
+          `${import.meta.env.VITE_PRODUCTION_URL + RAW_PATH.SIGNUP}`,
         );
     },
   });

--- a/src/screen/auth/ui/AuthScreen.tsx
+++ b/src/screen/auth/ui/AuthScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { useKakaoToken } from '@/screen/auth/api';
 import { Loader } from '@/assets/images';
-import { RAW_PATH } from '@/shared/constants';
+import { Button } from '@/shared/ui';
 
 export default function AuthScreen() {
   const params = new URLSearchParams(location.search);
@@ -23,14 +23,16 @@ export default function AuthScreen() {
         </div>
       )}
       {isError && (
-        <div className='flex flex-col text-lg'>
-          로그인에 실패했어요.
-          <button
+        <div className='flex w-full flex-col items-center justify-center gap-2 text-lg'>
+          <span>로그인에 실패했어요.</span>
+          <Button
+            size='sm'
             className='focus:outline-none'
-            onClick={() => window.history.replaceState(null, '', RAW_PATH.HOME)}
-          >
-            홈으로 돌아가기
-          </button>
+            onClick={() =>
+              window.location.replace(`${import.meta.env.VITE_PRODUCTION_URL}`)
+            }
+            label='홈으로 돌아가기'
+          />
         </div>
       )}
     </div>

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -1,7 +1,12 @@
 import { ActivityComponentType } from '@stackflow/react';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { RoomAppBar } from '@/shared/ui';
-import { MenuBottomSheet, RoomContainer } from '@/widgets/room/ui';
+import {
+  MenuBottomSheet,
+  RoomContainer,
+  RoomJoinFriendModal,
+  RoomJoinModal,
+} from '@/widgets/room/ui';
 import { RoomListItem } from '@/shared/types';
 import { useBottomSheet } from '@/shared/hook';
 import { BOTTOM_SHEET } from '@/shared/constants';
@@ -22,6 +27,8 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
         </div>
       </AppScreen>
       <MenuBottomSheet />
+      <RoomJoinModal />
+      <RoomJoinFriendModal />
     </>
   );
 };

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -12,6 +12,7 @@ import { RoomAuthority, RoomListItem } from '@/shared/types';
 import { useBottomSheet, useModal } from '@/shared/hook';
 import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
 import { fetchLoginStatus } from '@/shared/utils';
+import { useLeaveRoom } from '@/widgets/room/api';
 
 // 사용자 상태를 위한 타입 정의
 type RoomStatus = {
@@ -30,9 +31,10 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
   });
   const [isLogin, setIsLogin] = useState<boolean>(false);
 
+  const { maxParticipants, id } = params;
+  const { mutate: leave } = useLeaveRoom(id);
   const { openBottomSheet } = useBottomSheet();
   const { openModal } = useModal();
-  const { maxParticipants, id } = params;
 
   useEffect(() => {
     setIsLogin(fetchLoginStatus());
@@ -57,9 +59,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
     console.log('이동 to 채팅방:', id);
   };
 
-  const handleLeaveRoom = () => {
-    console.log('방 나가기:', id);
-  };
+  const handleLeaveRoom = () => leave(id);
 
   const renderActionButtons = () => {
     if (isLogin && status.status === 'pending') {

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -1,6 +1,6 @@
 import { ActivityComponentType } from '@stackflow/react';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { RoomAppBar } from '@/shared/ui';
+import { Button, RoomAppBar } from '@/shared/ui';
 import {
   MenuBottomSheet,
   RoomContainer,
@@ -8,8 +8,9 @@ import {
   RoomJoinModal,
 } from '@/widgets/room/ui';
 import { RoomListItem } from '@/shared/types';
-import { useBottomSheet } from '@/shared/hook';
-import { BOTTOM_SHEET } from '@/shared/constants';
+import { useBottomSheet, useModal } from '@/shared/hook';
+import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
+import { fetchLoginStatus } from '@/shared/utils';
 
 const RoomScreen: ActivityComponentType<RoomListItem> = ({
   params,
@@ -17,7 +18,23 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
   params: RoomListItem;
 }) => {
   const { openBottomSheet } = useBottomSheet();
+  const { openModal } = useModal();
+  const { maxParticipants, currentParticipants } = params;
+
+  const isLogin = fetchLoginStatus();
+  const availableFriendCnt = maxParticipants - currentParticipants - 1;
+  const isAvailableWithFriend = maxParticipants - currentParticipants - 1 >= 1;
+
   const handleMenuClick = () => openBottomSheet(BOTTOM_SHEET.MENU);
+
+  const handleJoin = () => {
+    if (isLogin) openModal(MODAL.JOIN);
+    else openBottomSheet(BOTTOM_SHEET.LOGIN);
+  };
+  const handleJoinWithFriend = () => {
+    if (isLogin) openModal(MODAL.JOIN_WITH_FRIEND);
+    else openBottomSheet(BOTTOM_SHEET.LOGIN);
+  };
 
   return (
     <>
@@ -26,9 +43,27 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
           <RoomContainer {...params} />
         </div>
       </AppScreen>
+      <div className='border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white'>
+        <Button
+          name='room-participate'
+          label='참여하기'
+          halfWidth={isAvailableWithFriend}
+          onClick={handleJoin}
+          className='mb-normal-spacing'
+        />
+        {isAvailableWithFriend && (
+          <Button
+            name='room-participate-with-friend'
+            label='친구와 함께 참여하기'
+            halfWidth
+            onClick={handleJoinWithFriend}
+            className='mb-normal-spacing'
+          />
+        )}
+      </div>
       <MenuBottomSheet />
       <RoomJoinModal />
-      <RoomJoinFriendModal />
+      <RoomJoinFriendModal availableFriendCnt={availableFriendCnt} />
     </>
   );
 };

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -32,14 +32,14 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
 
   const { openBottomSheet } = useBottomSheet();
   const { openModal } = useModal();
-  const { maxParticipants, currentParticipants, id } = params;
+  const { maxParticipants, id } = params;
 
   useEffect(() => {
     setIsLogin(fetchLoginStatus());
   }, []);
 
-  const availableFriendCnt = maxParticipants - currentParticipants - 1;
-  const isAvailableWithFriend = availableFriendCnt >= 1;
+  const availableFriendCnt = maxParticipants / 2 - 1;
+  const isAvailableWithFriend = maxParticipants !== 2;
 
   const handleMenuClick = () => openBottomSheet(BOTTOM_SHEET.MENU);
 
@@ -65,20 +65,19 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
     if (isLogin && status.status === 'pending') {
       return (
         <>
-          <Button
-            name='room-participate'
-            label=' '
-            halfWidth={isAvailableWithFriend}
-            onClick={() => {}}
-            className='skeleton'
-          />
-          {isAvailableWithFriend && (
+          {isAvailableWithFriend ? (
             <Button
               name='room-participate-with-friend'
-              label=' '
-              halfWidth
-              onClick={() => {}}
-              className='skeleton'
+              label='친구와 함께 참여하기'
+              onClick={handleJoinWithFriend}
+              className='mb-normal-spacing'
+            />
+          ) : (
+            <Button
+              name='room-participate'
+              label='참여하기'
+              onClick={handleJoin}
+              className='mb-normal-spacing'
             />
           )}
         </>
@@ -119,19 +118,18 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
 
     return (
       <>
-        <Button
-          name='room-participate'
-          label='참여하기'
-          halfWidth={isAvailableWithFriend}
-          onClick={handleJoin}
-          className='mb-normal-spacing'
-        />
-        {isAvailableWithFriend && (
+        {isAvailableWithFriend ? (
           <Button
             name='room-participate-with-friend'
             label='친구와 함께 참여하기'
-            halfWidth
             onClick={handleJoinWithFriend}
+            className='mb-normal-spacing'
+          />
+        ) : (
+          <Button
+            name='room-participate'
+            label='참여하기'
+            onClick={handleJoin}
             className='mb-normal-spacing'
           />
         )}

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -19,7 +19,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
 }) => {
   const { openBottomSheet } = useBottomSheet();
   const { openModal } = useModal();
-  const { maxParticipants, currentParticipants } = params;
+  const { maxParticipants, currentParticipants, id } = params;
 
   const isLogin = fetchLoginStatus();
   const availableFriendCnt = maxParticipants - currentParticipants - 1;
@@ -62,8 +62,11 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
         )}
       </div>
       <MenuBottomSheet />
-      <RoomJoinModal />
-      <RoomJoinFriendModal availableFriendCnt={availableFriendCnt} />
+      <RoomJoinModal roomId={id} />
+      <RoomJoinFriendModal
+        availableFriendCnt={availableFriendCnt}
+        roomId={id}
+      />
     </>
   );
 };

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,3 +1,4 @@
 export * from './axios';
 export * from './requests';
 export * from './list';
+export * from './user';

--- a/src/shared/api/list.ts
+++ b/src/shared/api/list.ts
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { get } from '@/shared/api';
 import { RoomListItem } from '@/shared/types';
-import { getCookie } from '@/shared/utils';
+import { userGet } from '@/shared/api';
 
 interface FetchRoomListResponse {
   result: {
@@ -36,9 +35,8 @@ interface FetchRoomListResponse {
 }
 
 const fetchRoomList = async (request: string) => {
-  const response = await get<FetchRoomListResponse>({
+  const response = await userGet<FetchRoomListResponse>({
     request: request,
-    headers: { Authorization: `Bearer ${getCookie()}` },
   });
   return response.data.result;
 };

--- a/src/shared/api/requests.ts
+++ b/src/shared/api/requests.ts
@@ -2,7 +2,7 @@ export const REQUEST = {
   ROOM: '/rooms',
   ROOM_JOIN: '/rooms/{roomId}/participations',
   ROOM_LEAVE: '/rooms/{roomId}/leave',
-  ROOM_PARTICIPATED: '/rooms/participate',
+  ROOM_PARTICIPATED: '/rooms/participations',
   KAKAO: '/auth/kakao',
   LOGIN: '/auth/login',
   SIGNUP: '/auth/register/profile',

--- a/src/shared/api/requests.ts
+++ b/src/shared/api/requests.ts
@@ -1,5 +1,6 @@
 export const REQUEST = {
   ROOM: '/rooms',
+  ROOM_JOIN: '/rooms/{roomId}/participations',
   ROOM_PARTICIPATED: '/rooms/participate',
   KAKAO: '/auth/kakao',
   LOGIN: '/auth/login',

--- a/src/shared/api/requests.ts
+++ b/src/shared/api/requests.ts
@@ -1,6 +1,7 @@
 export const REQUEST = {
   ROOM: '/rooms',
   ROOM_JOIN: '/rooms/{roomId}/participations',
+  ROOM_LEAVE: '/rooms/{roomId}/leave',
   ROOM_PARTICIPATED: '/rooms/participate',
   KAKAO: '/auth/kakao',
   LOGIN: '/auth/login',

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -3,7 +3,7 @@ import axios, { AxiosHeaders, AxiosResponse } from 'axios';
 interface PostRequestParams<TData> {
   request: string;
   headers?: AxiosHeaders;
-  data: TData;
+  data?: TData;
 }
 
 interface GetRequestParams<TParams> {

--- a/src/shared/atom/index.ts
+++ b/src/shared/atom/index.ts
@@ -1,2 +1,3 @@
 export * from './user';
 export * from './bottomSheet';
+export * from './modal';

--- a/src/shared/atom/modal.ts
+++ b/src/shared/atom/modal.ts
@@ -1,0 +1,26 @@
+import { atom } from 'jotai';
+
+import type { ModalItem } from '@/shared/types';
+import { MODAL } from '@/shared/constants';
+
+type ModalInfo = {
+  [key in ModalItem]: { isOpen: boolean };
+};
+
+const modals = Object.fromEntries(
+  Object.keys(MODAL).map(key => [key, { isOpen: false }]),
+) as ModalInfo;
+
+export const modalAtom = atom<ModalInfo>(modals);
+
+export const updateModal = atom(
+  null,
+  (get, set, update: { key: ModalItem; isOpen: boolean }) => {
+    const currentModal = get(modalAtom);
+    const updatedModal = {
+      ...currentModal,
+      [update.key]: { isOpen: update.isOpen },
+    };
+    set(modalAtom, updatedModal);
+  },
+);

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -3,3 +3,4 @@ export * from './path';
 export * from './gender';
 export * from './bottomSheet';
 export * from './status';
+export * from './modal';

--- a/src/shared/constants/modal.ts
+++ b/src/shared/constants/modal.ts
@@ -1,4 +1,4 @@
 export const MODAL = {
   JOIN: 'joinModal',
-  JOIN_WITH_FREIND: 'joinWithFriendModal',
+  JOIN_WITH_FRIEND: 'joinWithFriendModal',
 } as const;

--- a/src/shared/constants/modal.ts
+++ b/src/shared/constants/modal.ts
@@ -1,0 +1,4 @@
+export const MODAL = {
+  JOIN: 'joinModal',
+  JOIN_WITH_FREIND: 'joinWithFriendModal',
+} as const;

--- a/src/shared/constants/status.ts
+++ b/src/shared/constants/status.ts
@@ -1,5 +1,5 @@
 export const ROOM_STATUS: Record<string, string> = {
   MATCHING: '매칭중',
-  MATCHED: '매칭완료',
-  CLOSED: '종료',
+  MATCHED: '매칭 완료',
+  CLOSED: '모임 종료',
 };

--- a/src/shared/hook/index.ts
+++ b/src/shared/hook/index.ts
@@ -1,1 +1,2 @@
 export { default as useBottomSheet } from './useBottomSheet';
+export { default as useModal } from './useModal';

--- a/src/shared/hook/index.ts
+++ b/src/shared/hook/index.ts
@@ -1,2 +1,3 @@
 export { default as useBottomSheet } from './useBottomSheet';
 export { default as useModal } from './useModal';
+export { default as useOutsideClick } from './useOutsideClick';

--- a/src/shared/hook/useModal.ts
+++ b/src/shared/hook/useModal.ts
@@ -1,0 +1,15 @@
+import { useAtomValue, useSetAtom } from 'jotai';
+
+import { modalAtom, updateModal } from '@/shared/atom';
+import { ModalItem } from '@/shared/types';
+
+export default function useModal() {
+  const modal = useAtomValue(modalAtom);
+  const setModal = useSetAtom(updateModal);
+
+  const modalState = (key: ModalItem) => modal[key] || { isOpen: false };
+  const openModal = (key: ModalItem) => setModal({ key: key, isOpen: true });
+  const closeModal = (key: ModalItem) => setModal({ key: key, isOpen: false });
+
+  return { modalState, openModal, closeModal };
+}

--- a/src/shared/hook/useOutsideClick.ts
+++ b/src/shared/hook/useOutsideClick.ts
@@ -1,0 +1,25 @@
+import { useEffect, type RefObject } from 'react';
+
+export default function useOnClickOutside(
+  ref: RefObject<HTMLElement> | RefObject<null>,
+  handler: () => void,
+) {
+  useEffect(() => {
+    if (ref) {
+      const listener = (event: MouseEvent | TouchEvent) => {
+        if (!ref.current || ref.current.contains(event.target as Node)) {
+          return;
+        }
+        handler();
+      };
+
+      document.addEventListener('mousedown', listener);
+      document.addEventListener('touchstart', listener);
+
+      return () => {
+        document.removeEventListener('mousedown', listener);
+        document.removeEventListener('touchstart', listener);
+      };
+    }
+  }, [ref, handler]);
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,3 +3,4 @@ export * from './path';
 export * from './room';
 export * from './gender';
 export * from './bottomSheet';
+export * from './modal';

--- a/src/shared/types/modal.ts
+++ b/src/shared/types/modal.ts
@@ -1,0 +1,3 @@
+import { MODAL } from '@/shared/constants';
+
+export type ModalItem = (typeof MODAL)[keyof typeof MODAL];

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -3,6 +3,7 @@ import { Gender } from '@/shared/types';
 export type Room = Partial<FormData> & {
   id: number;
   headCount: 2 | 4 | 6;
+  maxParticipants: 2 | 4 | 6;
   status: string;
   preferredGender: Gender;
   preferredStudentIdMin: string;
@@ -13,7 +14,14 @@ export type Room = Partial<FormData> & {
   place: string;
 };
 
-export type RoomDetail = Room & {
+export type RoomAuthority =
+  | 'HOST'
+  | 'PARTICIPANT'
+  | 'NON_PARTICIPANT'
+  | 'NON_MEMBER';
+
+export type RoomDetail = RoomListItem & {
+  roomAuthority: RoomAuthority;
   hostParticipants: RoomParticipant[];
   guestParticipants: RoomParticipant[];
 };
@@ -27,8 +35,7 @@ export type RoomParticipant = {
   isHost: boolean;
 };
 
-export type RoomListItem = Omit<Room, 'headCount'> & {
-  maxParticipants: number;
+export type RoomListItem = Room & {
   currentParticipants: number;
   thumbnail: {
     name: string;

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -2,7 +2,6 @@ import { Gender } from '@/shared/types';
 
 export type Room = Partial<FormData> & {
   id: number;
-  headCount: 2 | 4 | 6;
   maxParticipants: 2 | 4 | 6;
   status: string;
   preferredGender: Gender;

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -9,11 +9,12 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
   halfWidth?: boolean;
   shadow?: boolean;
+  noMargins?: boolean;
   size?: Size;
 }
 
 const SIZE: Record<Size, string> = {
-  lg: 'py-3.5 mb-normal-spacing z-30 rounded-10',
+  lg: 'py-3.5 z-30 rounded-10',
   md: 'py-2.5 rounded-10',
   sm: 'py-2 px-4 rounded-5 border-border bg-fill w-fit text-dark border-[1px] disabled:text-light hover:bg-sub',
 };
@@ -25,6 +26,7 @@ export default function Button({
   name,
   type,
   halfWidth = false,
+  noMargins = false,
   shadow = false,
   className,
   size = 'lg',
@@ -36,6 +38,7 @@ export default function Button({
       type={type || 'button'}
       className={cn(
         'hover:bg-point-hover bg-point text-md disabled:bg-sub disabled:text-border flex-shrink-0 cursor-pointer font-medium text-white transition duration-300',
+        noMargins && size === 'lg' ? 'm-0' : 'mb-normal-spacing',
         halfWidth ? 'flex-1' : 'w-full',
         shadow && 'box-shadow-button',
         className,

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -26,7 +26,6 @@ export default function Button({
   name,
   type,
   halfWidth = false,
-  noMargins = false,
   shadow = false,
   className,
   size = 'lg',
@@ -38,7 +37,6 @@ export default function Button({
       type={type || 'button'}
       className={cn(
         'hover:bg-point-hover bg-point text-md disabled:bg-sub disabled:text-border flex-shrink-0 cursor-pointer font-medium text-white transition duration-300',
-        noMargins && size === 'lg' ? 'm-0' : 'mb-normal-spacing',
         halfWidth ? 'flex-1' : 'w-full',
         shadow && 'box-shadow-button',
         className,

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,0 +1,26 @@
+import React, { useRef, type ReactNode } from 'react';
+
+import { ModalItem } from '@/shared/types';
+import { useModal, useOutsideClick } from '../hook';
+
+interface ModalProps {
+  children: ReactNode;
+  modalKey: ModalItem;
+}
+
+export default function Modal({ children, modalKey }: ModalProps) {
+  const { closeModal } = useModal();
+  const ref = useRef<HTMLDivElement>(null);
+  useOutsideClick(ref, () => closeModal(modalKey));
+
+  return (
+    <div className='absolute inset-0 z-300 grid size-full place-items-center bg-black/20'>
+      <div
+        className='rounded-10 z-400 flex w-[80%] max-w-[350px] flex-col gap-2 bg-white p-6'
+        ref={ref}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -12,5 +12,6 @@ export { default as GroupList } from './GroupList';
 export { default as Button } from './Button';
 export { default as LoginBottomSheet } from './LoginBottomSheet';
 export { default as BottomSheet } from './BottomSheet';
+export { default as Modal } from './Modal';
 
 export * from './AppBar';

--- a/src/widgets/create/api/create.ts
+++ b/src/widgets/create/api/create.ts
@@ -1,9 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { REQUEST, useRoomList } from '@/shared/api';
-import { userPost } from '@/shared/api/user';
-
 import { useFlow } from '@/app/stackflow';
+
+import { REQUEST, useRoomList, userPost } from '@/shared/api';
 
 const submitRoomCreation = async (data: FormData) => {
   await userPost<FormData>({

--- a/src/widgets/create/model/constants/form.ts
+++ b/src/widgets/create/model/constants/form.ts
@@ -1,5 +1,5 @@
 export const DETAIL_OPTION = {
-  headCount: [
+  maxParticipants: [
     { id: 'people-2', value: 2, label: '2명 (1:1)' },
     { id: 'people-4', value: 4, label: '4명 (2:2)' },
     { id: 'people-6', value: 6, label: '6명 (3:3)' },

--- a/src/widgets/create/model/contexts/create.ts
+++ b/src/widgets/create/model/contexts/create.ts
@@ -3,8 +3,8 @@ import { createContext, type Dispatch, type SetStateAction } from 'react';
 export const RoomCreateContext = createContext<{
   mode: number;
   setMode: Dispatch<SetStateAction<number>>;
-  headCountRender: number;
-  setHeadCountRender: Dispatch<SetStateAction<number>>;
+  maxParticipantsRender: number;
+  setMaxParticipantsRender: Dispatch<SetStateAction<number>>;
   file: File | undefined;
   setFile: Dispatch<SetStateAction<File | undefined>>;
   image: string;

--- a/src/widgets/create/model/hooks/useFormMode.tsx
+++ b/src/widgets/create/model/hooks/useFormMode.tsx
@@ -26,7 +26,7 @@ export default function useFormMode({
   watch,
   setValue,
 }: RoomModeProps) {
-  const { title, content, preferredGender, headCount, place } = watch();
+  const { title, content, preferredGender, maxParticipants, place } = watch();
 
   const MODE = [
     {
@@ -50,7 +50,7 @@ export default function useFormMode({
         />
       ),
       button: '생성하기',
-      isFormValid: preferredGender && headCount,
+      isFormValid: preferredGender && maxParticipants,
     },
   ];
 

--- a/src/widgets/create/model/providers/create.tsx
+++ b/src/widgets/create/model/providers/create.tsx
@@ -4,7 +4,7 @@ import { RoomCreateContext } from '@/widgets/create/model';
 
 export default function CreateProvider({ children }: { children: ReactNode }) {
   const [mode, setMode] = useState(0);
-  const [headCountRender, setHeadCountRender] = useState(2);
+  const [maxParticipantsRender, setMaxParticipantsRender] = useState(2);
   const [file, setFile] = useState<File | undefined>(undefined);
   const [image, setImage] = useState<string>('');
 
@@ -13,8 +13,8 @@ export default function CreateProvider({ children }: { children: ReactNode }) {
       value={{
         mode,
         setMode,
-        headCountRender,
-        setHeadCountRender,
+        maxParticipantsRender,
+        setMaxParticipantsRender,
         file,
         setFile,
         image,

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -71,6 +71,7 @@ export default function CreateContainer() {
           else handleSubmit();
         }}
         label={isPending ? '방을 만드는 중..' : button}
+        className='mb-normal-spacing'
       />
     </form>
   );

--- a/src/widgets/create/ui/CreateContainer.tsx
+++ b/src/widgets/create/ui/CreateContainer.tsx
@@ -30,7 +30,7 @@ export default function CreateContainer() {
     formData.append('imageFiles', file!);
     const postData = JSON.stringify({
       ...watch(),
-      headCount: Number(watch('headCount')) as 2 | 4 | 6,
+      maxParticipants: Number(watch('maxParticipants')) as 2 | 4 | 6,
     });
     const blob = new Blob([postData], { type: 'application/json' });
     formData.append('request', blob);

--- a/src/widgets/create/ui/GroupDetailForm.tsx
+++ b/src/widgets/create/ui/GroupDetailForm.tsx
@@ -24,12 +24,13 @@ export default function GroupDetailForm({
 }: GroupTitleFormProps) {
   const {
     preferredGender,
-    headCount,
+    maxParticipants,
     meetingDateTime,
     preferredStudentIdMin,
     preferredStudentIdMax,
   } = watch();
-  const { headCountRender, setHeadCountRender } = useRoomCreateContext();
+  const { maxParticipantsRender, setMaxParticipantsRender } =
+    useRoomCreateContext();
 
   return (
     <>
@@ -75,21 +76,21 @@ export default function GroupDetailForm({
         title='인원 선택'
         description='1:1은 2명, 2:2는 4명, 3:3은 6명을 선택해주세요.'
       >
-        {DETAIL_OPTION.headCount.map(({ id, value, label }) => (
+        {DETAIL_OPTION.maxParticipants.map(({ id, value, label }) => (
           <Radio
             key={id}
             id={id}
             value={value}
             label={label}
-            checked={Number(headCount) === value}
+            checked={Number(maxParticipants) === value}
             onChange={() => {
-              setHeadCountRender(value);
-              setValue('headCount', value);
+              setMaxParticipantsRender(value);
+              setValue('maxParticipants', value);
             }}
           />
         ))}
       </FormItem>
-      {headCountRender !== 2 && (
+      {maxParticipantsRender !== 2 && (
         <FormItem
           title='친구'
           description={
@@ -101,7 +102,7 @@ export default function GroupDetailForm({
           className='flex flex-col gap-2'
         >
           <FriendInput />
-          {headCountRender === 6 && <FriendInput />}
+          {maxParticipantsRender === 6 && <FriendInput />}
         </FormItem>
       )}
       <FormItem

--- a/src/widgets/room/api/index.ts
+++ b/src/widgets/room/api/index.ts
@@ -1,2 +1,3 @@
 export * from './room';
 export * from './join';
+export * from './leave';

--- a/src/widgets/room/api/index.ts
+++ b/src/widgets/room/api/index.ts
@@ -1,1 +1,2 @@
 export * from './room';
+export * from './join';

--- a/src/widgets/room/api/join.ts
+++ b/src/widgets/room/api/join.ts
@@ -1,7 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { REQUEST } from '@/shared/api';
-import { userPost } from '@/shared/api/user';
+import { REQUEST, userPost } from '@/shared/api';
 import { useModal } from '@/shared/hook';
 import { MODAL } from '@/shared/constants';
 

--- a/src/widgets/room/api/join.ts
+++ b/src/widgets/room/api/join.ts
@@ -1,0 +1,35 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { REQUEST } from '@/shared/api';
+import { userPost } from '@/shared/api/user';
+import { useModal } from '@/shared/hook';
+import { MODAL } from '@/shared/constants';
+
+import { useRoomDetail } from '@/widgets/room/api';
+
+interface SubmitRoomJoinRequest {
+  friendPhoneNumbers: string[];
+}
+
+const submitRoomJoin = async (
+  roomId: number,
+  friendPhoneNumbers?: string[],
+) => {
+  await userPost<SubmitRoomJoinRequest>({
+    request: REQUEST.ROOM_JOIN.split('{roomId}').join(`${roomId}`).toString(),
+    data: { friendPhoneNumbers: friendPhoneNumbers ?? [] },
+  });
+};
+
+export const useSubmitRoomJoin = (roomId: number) => {
+  const { refetch } = useRoomDetail(roomId);
+  const { closeModal } = useModal();
+
+  return useMutation({
+    mutationFn: submitRoomJoin,
+    onSuccess: () => {
+      refetch();
+      closeModal(MODAL.JOIN);
+    },
+  });
+};

--- a/src/widgets/room/api/join.ts
+++ b/src/widgets/room/api/join.ts
@@ -5,7 +5,7 @@ import { userPost } from '@/shared/api/user';
 import { useModal } from '@/shared/hook';
 import { MODAL } from '@/shared/constants';
 
-import { useRoomDetail } from '@/widgets/room/api';
+import { useUserRoomDetail } from '@/widgets/room/api';
 
 interface SubmitRoomJoinRequest {
   friendPhoneNumbers: string[];
@@ -22,7 +22,7 @@ const submitRoomJoin = async (
 };
 
 export const useSubmitRoomJoin = (roomId: number) => {
-  const { refetch } = useRoomDetail(roomId);
+  const { refetch } = useUserRoomDetail(roomId);
   const { closeModal } = useModal();
 
   return useMutation({

--- a/src/widgets/room/api/leave.ts
+++ b/src/widgets/room/api/leave.ts
@@ -1,7 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { REQUEST } from '@/shared/api';
-import { userPost } from '@/shared/api/user';
+import { REQUEST, userPost } from '@/shared/api';
 
 import { useUserRoomDetail } from '@/widgets/room/api';
 

--- a/src/widgets/room/api/leave.ts
+++ b/src/widgets/room/api/leave.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { REQUEST } from '@/shared/api';
+import { userPost } from '@/shared/api/user';
+
+import { useUserRoomDetail } from '@/widgets/room/api';
+
+const submitLeaveRoom = async (roomId: number) => {
+  await userPost({
+    request: REQUEST.ROOM_LEAVE.split('{roomId}')
+      .join(roomId.toString())
+      .toString(),
+  });
+};
+
+export const useLeaveRoom = (roomId: number) => {
+  const { refetch } = useUserRoomDetail(roomId);
+
+  return useMutation({
+    mutationFn: submitLeaveRoom,
+    onSuccess: () => refetch(),
+  });
+};

--- a/src/widgets/room/api/room.ts
+++ b/src/widgets/room/api/room.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { get, REQUEST } from '@/shared/api';
-import { userGet } from '@/shared/api/user';
+import { get, userGet, REQUEST } from '@/shared/api';
 import { RoomDetail } from '@/shared/types';
 import { getPath } from '@/shared/utils';
 

--- a/src/widgets/room/api/room.ts
+++ b/src/widgets/room/api/room.ts
@@ -1,18 +1,32 @@
-import { get, REQUEST } from '@/shared/api';
-import { RoomDetail } from '@/shared/types';
-import { getCookie } from '@/shared/utils';
 import { useQuery } from '@tanstack/react-query';
+
+import { get, REQUEST } from '@/shared/api';
+import { userGet } from '@/shared/api/user';
+import { RoomDetail } from '@/shared/types';
+import { getPath } from '@/shared/utils';
 
 interface FetchRoomResponse {
   result: RoomDetail;
 }
 
-export const fetchRoomDetail = async ({ roomId }: { roomId: number }) => {
-  const response = await get<FetchRoomResponse>({
-    request: REQUEST.ROOM + '/' + roomId,
-    headers: { Authorization: `Bearer ${getCookie()}` },
+const fetchUserRoomDetail = async ({ roomId }: { roomId: number }) => {
+  const response = await userGet<FetchRoomResponse>({
+    request: getPath(REQUEST.ROOM, `${roomId}`),
   });
   return response.data.result;
+};
+const fetchRoomDetail = async ({ roomId }: { roomId: number }) => {
+  const response = await get<FetchRoomResponse>({
+    request: getPath(REQUEST.ROOM, `${roomId}`),
+  });
+  return response.data.result;
+};
+
+export const useUserRoomDetail = (roomId: number) => {
+  return useQuery({
+    queryKey: [`room + ${roomId}`],
+    queryFn: () => fetchUserRoomDetail({ roomId }),
+  });
 };
 
 export const useRoomDetail = (roomId: number) => {

--- a/src/widgets/room/api/room.ts
+++ b/src/widgets/room/api/room.ts
@@ -24,14 +24,14 @@ const fetchRoomDetail = async ({ roomId }: { roomId: number }) => {
 
 export const useUserRoomDetail = (roomId: number) => {
   return useQuery({
-    queryKey: [`room + ${roomId}`],
+    queryKey: ['roomDetail', roomId],
     queryFn: () => fetchUserRoomDetail({ roomId }),
   });
 };
 
 export const useRoomDetail = (roomId: number) => {
   return useQuery({
-    queryKey: [`room + ${roomId}`],
+    queryKey: ['roomDetail', roomId],
     queryFn: () => fetchRoomDetail({ roomId }),
   });
 };

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction, useEffect } from 'react';
 
 import { FormItem } from '@/shared/ui';
-import { RoomListItem } from '@/shared/types';
+import { RoomAuthority, RoomListItem } from '@/shared/types';
 
 import { RoomHeader, UserItem } from '@/widgets/room/ui';
-import { useRoomDetail } from '@/widgets/room/api';
+import { useRoomDetail, useUserRoomDetail } from '@/widgets/room/api';
+import { fetchLoginStatus } from '@/shared/utils';
 
-export default function RoomContainer(props: RoomListItem) {
-  const { id, content } = props;
-  const { data, isLoading } = useRoomDetail(id);
+type RoomContainerProps = RoomListItem & {
+  setStatus: Dispatch<
+    SetStateAction<{
+      status: 'pending' | 'success';
+      data: RoomAuthority | null;
+    }>
+  >;
+};
+
+export default function RoomContainer(props: RoomContainerProps) {
+  const { id, content, setStatus } = props;
+  const isLoggedIn = fetchLoginStatus();
+  const roomDetail = isLoggedIn ? useUserRoomDetail : useRoomDetail;
+  const { data, isLoading } = roomDetail(id);
+
+  useEffect(() => {
+    if (isLoading) setStatus(prev => ({ ...prev, status: 'pending' }));
+    if (data)
+      setStatus(() => ({ data: data.roomAuthority, status: 'success' }));
+  }, [data, isLoading, setStatus]);
 
   return (
     <div className='flex size-full flex-col justify-between'>

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -6,17 +6,23 @@ import { RoomListItem } from '@/shared/types';
 import { RoomHeader, UserItem } from '@/widgets/room/ui';
 import { useRoomDetail } from '@/widgets/room/api';
 import { fetchLoginStatus } from '@/shared/utils';
-import { useBottomSheet } from '@/shared/hook';
-import { BOTTOM_SHEET } from '@/shared/constants';
+import { useBottomSheet, useModal } from '@/shared/hook';
+import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
 
 export default function RoomContainer(props: RoomListItem) {
-  const { id, content } = props;
+  const { id, content, maxParticipants } = props;
   const { data, isLoading } = useRoomDetail(id);
   const { openBottomSheet } = useBottomSheet();
+  const { openModal } = useModal();
   const isLogin = fetchLoginStatus();
+  const isOneToOne = maxParticipants === 2;
 
   const handleJoin = () => {
-    if (isLogin) console.log('참여하기 모달이 열립니다.');
+    if (isLogin) openModal(MODAL.JOIN);
+    else openBottomSheet(BOTTOM_SHEET.LOGIN);
+  };
+  const handleJoinWithFriend = () => {
+    if (isLogin) openModal(MODAL.JOIN_WITH_FRIEND);
     else openBottomSheet(BOTTOM_SHEET.LOGIN);
   };
 
@@ -65,15 +71,17 @@ export default function RoomContainer(props: RoomListItem) {
         <Button
           name='room-participate'
           label='참여하기'
-          halfWidth
+          halfWidth={!isOneToOne}
           onClick={handleJoin}
         />
-        <Button
-          name='room-participate-with-friend'
-          label='친구와 함께 참여하기'
-          halfWidth
-          onClick={handleJoin}
-        />
+        {!isOneToOne && (
+          <Button
+            name='room-participate-with-friend'
+            label='친구와 함께 참여하기'
+            halfWidth
+            onClick={handleJoinWithFriend}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -1,30 +1,14 @@
 import React from 'react';
 
-import { Button, FormItem } from '@/shared/ui';
+import { FormItem } from '@/shared/ui';
 import { RoomListItem } from '@/shared/types';
 
 import { RoomHeader, UserItem } from '@/widgets/room/ui';
 import { useRoomDetail } from '@/widgets/room/api';
-import { fetchLoginStatus } from '@/shared/utils';
-import { useBottomSheet, useModal } from '@/shared/hook';
-import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
 
 export default function RoomContainer(props: RoomListItem) {
-  const { id, content, maxParticipants } = props;
+  const { id, content } = props;
   const { data, isLoading } = useRoomDetail(id);
-  const { openBottomSheet } = useBottomSheet();
-  const { openModal } = useModal();
-  const isLogin = fetchLoginStatus();
-  const isOneToOne = maxParticipants === 2;
-
-  const handleJoin = () => {
-    if (isLogin) openModal(MODAL.JOIN);
-    else openBottomSheet(BOTTOM_SHEET.LOGIN);
-  };
-  const handleJoinWithFriend = () => {
-    if (isLogin) openModal(MODAL.JOIN_WITH_FRIEND);
-    else openBottomSheet(BOTTOM_SHEET.LOGIN);
-  };
 
   return (
     <div className='flex size-full flex-col justify-between'>
@@ -66,22 +50,6 @@ export default function RoomContainer(props: RoomListItem) {
           </>
         )}
         <div className='h-normal-spacing' />
-      </div>
-      <div className='border-t-app-bar-border z-30 flex h-fit w-full gap-x-3 border-[0.5px] pt-3 text-lg font-semibold text-white'>
-        <Button
-          name='room-participate'
-          label='참여하기'
-          halfWidth={!isOneToOne}
-          onClick={handleJoin}
-        />
-        {!isOneToOne && (
-          <Button
-            name='room-participate-with-friend'
-            label='친구와 함께 참여하기'
-            halfWidth
-            onClick={handleJoinWithFriend}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/widgets/room/ui/RoomJoinFriendModal.tsx
+++ b/src/widgets/room/ui/RoomJoinFriendModal.tsx
@@ -4,16 +4,23 @@ import { MODAL } from '@/shared/constants';
 import { Button, Input, Modal } from '@/shared/ui';
 import { useModal } from '@/shared/hook';
 
+import { useSubmitRoomJoin } from '@/widgets/room/api';
+
 interface RoomJoinFriendModalProps {
   availableFriendCnt: number;
+  roomId: number;
 }
 
 export default function RoomJoinFriendModal({
   availableFriendCnt,
+  roomId,
 }: RoomJoinFriendModalProps) {
   const { closeModal, modalState } = useModal();
+  const { mutate } = useSubmitRoomJoin(roomId);
   const { isOpen } = modalState(MODAL.JOIN_WITH_FRIEND);
+
   const onClose = () => closeModal(MODAL.JOIN_WITH_FRIEND);
+  const onJoin = () => mutate(roomId);
 
   return (
     <>
@@ -42,6 +49,7 @@ export default function RoomJoinFriendModal({
               label='함께 참여하기'
               className='m-0'
               size='md'
+              onClick={onJoin}
               disabled
             />
           </div>

--- a/src/widgets/room/ui/RoomJoinFriendModal.tsx
+++ b/src/widgets/room/ui/RoomJoinFriendModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { MODAL } from '@/shared/constants';
+import { Button, Modal } from '@/shared/ui';
+import { useModal } from '@/shared/hook';
+
+export default function RoomJoinModal() {
+  const { isOpen } = useModal().modalState(MODAL.JOIN_WITH_FRIEND);
+
+  return (
+    <>
+      {isOpen && (
+        <Modal modalKey={MODAL.JOIN_WITH_FRIEND}>
+          <p className='text-lg font-semibold'>친구와 함께 참여하기</p>
+          <p>함께할 친구를 불러주세요!</p>
+          <div className='mt-2 flex gap-3'>
+            <Button
+              halfWidth
+              noMargins
+              label='더 생각해 볼래요'
+              className='bg-border text-dark m-0'
+              size='lg'
+            />
+            <Button
+              halfWidth
+              noMargins
+              label='가입할래요'
+              className='m-0'
+              size='lg'
+            />
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/widgets/room/ui/RoomJoinFriendModal.tsx
+++ b/src/widgets/room/ui/RoomJoinFriendModal.tsx
@@ -1,32 +1,48 @@
 import React from 'react';
 
 import { MODAL } from '@/shared/constants';
-import { Button, Modal } from '@/shared/ui';
+import { Button, Input, Modal } from '@/shared/ui';
 import { useModal } from '@/shared/hook';
 
-export default function RoomJoinModal() {
-  const { isOpen } = useModal().modalState(MODAL.JOIN_WITH_FRIEND);
+interface RoomJoinFriendModalProps {
+  availableFriendCnt: number;
+}
+
+export default function RoomJoinFriendModal({
+  availableFriendCnt,
+}: RoomJoinFriendModalProps) {
+  const { closeModal, modalState } = useModal();
+  const { isOpen } = modalState(MODAL.JOIN_WITH_FRIEND);
+  const onClose = () => closeModal(MODAL.JOIN_WITH_FRIEND);
 
   return (
     <>
       {isOpen && (
         <Modal modalKey={MODAL.JOIN_WITH_FRIEND}>
           <p className='text-lg font-semibold'>친구와 함께 참여하기</p>
-          <p>함께할 친구를 불러주세요!</p>
+          <p>
+            함께할 친구를 불러주세요! 친구도 Festamate!에 가입되어 있어야 함께
+            참여할 수 있어요.
+          </p>
+          {Array.from({ length: availableFriendCnt }).map((_, i) => (
+            <FriendInput key={i} />
+          ))}
           <div className='mt-2 flex gap-3'>
             <Button
               halfWidth
               noMargins
               label='더 생각해 볼래요'
+              onClick={onClose}
               className='bg-border text-dark m-0'
-              size='lg'
+              size='md'
             />
             <Button
               halfWidth
               noMargins
-              label='가입할래요'
+              label='함께 참여하기'
               className='m-0'
-              size='lg'
+              size='md'
+              disabled
             />
           </div>
         </Modal>
@@ -34,3 +50,26 @@ export default function RoomJoinModal() {
     </>
   );
 }
+
+const FriendInput = () => (
+  <div className='flex w-full gap-2'>
+    <div className='flex-1'>
+      <Input
+        id='co-founder'
+        placeholder='전화번호'
+        type='phone'
+        // onChange={e => {
+        //   const rawValue = e.target.value;
+        //   const formattedValue = getFormattedPhone(rawValue);
+        // }} 차후 해당 로직 연결 & 데이터 패칭 진행하면 됩니다.
+      />
+    </div>
+    <button
+      id='co-founder'
+      type='button'
+      className='bg-fill rounded-5 border-border hover:bg-sub cursor-pointer border-[1px] px-4 py-2'
+    >
+      확인
+    </button>
+  </div>
+);

--- a/src/widgets/room/ui/RoomJoinModal.tsx
+++ b/src/widgets/room/ui/RoomJoinModal.tsx
@@ -5,28 +5,33 @@ import { Button, Modal } from '@/shared/ui';
 import { useModal } from '@/shared/hook';
 
 export default function RoomJoinModal() {
-  const { isOpen } = useModal().modalState(MODAL.JOIN);
+  const { closeModal, modalState } = useModal();
+  const { isOpen } = modalState(MODAL.JOIN);
+  const onClose = () => closeModal(MODAL.JOIN);
 
   return (
     <>
       {isOpen && (
         <Modal modalKey={MODAL.JOIN}>
-          <p className='text-lg font-semibold'>모임방 가입하기</p>
-          <p>티켓 한 장을 소모하고 모임방에 가입할까요?</p>
+          <p className='text-lg font-semibold'>모임방 참여하기</p>
+          <p>티켓 한 장을 소모하고 모임방에 참여할까요?</p>
           <div className='mt-2 flex gap-3'>
             <Button
               halfWidth
               noMargins
+              name='joinWithdraw'
               label='더 생각해 볼래요'
               className='bg-border text-dark m-0'
-              size='lg'
+              size='md'
+              onClick={onClose}
             />
             <Button
               halfWidth
               noMargins
-              label='가입할래요'
+              name='joinConfirm'
+              label='참여할래요'
               className='m-0'
-              size='lg'
+              size='md'
             />
           </div>
         </Modal>

--- a/src/widgets/room/ui/RoomJoinModal.tsx
+++ b/src/widgets/room/ui/RoomJoinModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { MODAL } from '@/shared/constants';
+import { Button, Modal } from '@/shared/ui';
+import { useModal } from '@/shared/hook';
+
+export default function RoomJoinModal() {
+  const { isOpen } = useModal().modalState(MODAL.JOIN);
+
+  return (
+    <>
+      {isOpen && (
+        <Modal modalKey={MODAL.JOIN}>
+          <p className='text-lg font-semibold'>모임방 가입하기</p>
+          <p>티켓 한 장을 소모하고 모임방에 가입할까요?</p>
+          <div className='mt-2 flex gap-3'>
+            <Button
+              halfWidth
+              noMargins
+              label='더 생각해 볼래요'
+              className='bg-border text-dark m-0'
+              size='lg'
+            />
+            <Button
+              halfWidth
+              noMargins
+              label='가입할래요'
+              className='m-0'
+              size='lg'
+            />
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/widgets/room/ui/RoomJoinModal.tsx
+++ b/src/widgets/room/ui/RoomJoinModal.tsx
@@ -4,36 +4,54 @@ import { MODAL } from '@/shared/constants';
 import { Button, Modal } from '@/shared/ui';
 import { useModal } from '@/shared/hook';
 
-export default function RoomJoinModal() {
+import { useSubmitRoomJoin } from '@/widgets/room/api';
+
+interface RoomJoinModalProps {
+  roomId: number;
+}
+
+export default function RoomJoinModal({ roomId }: RoomJoinModalProps) {
   const { closeModal, modalState } = useModal();
+  const { mutate, isError } = useSubmitRoomJoin(roomId);
   const { isOpen } = modalState(MODAL.JOIN);
+
   const onClose = () => closeModal(MODAL.JOIN);
+  const onJoin = () => mutate(roomId);
 
   return (
     <>
       {isOpen && (
         <Modal modalKey={MODAL.JOIN}>
-          <p className='text-lg font-semibold'>모임방 참여하기</p>
-          <p>티켓 한 장을 소모하고 모임방에 참여할까요?</p>
-          <div className='mt-2 flex gap-3'>
-            <Button
-              halfWidth
-              noMargins
-              name='joinWithdraw'
-              label='더 생각해 볼래요'
-              className='bg-border text-dark m-0'
-              size='md'
-              onClick={onClose}
-            />
-            <Button
-              halfWidth
-              noMargins
-              name='joinConfirm'
-              label='참여할래요'
-              className='m-0'
-              size='md'
-            />
-          </div>
+          {!isError ? (
+            <>
+              <p className='text-lg font-semibold'>모임방 참여하기</p>
+              <p>티켓 한 장을 소모하고 모임방에 참여할까요?</p>
+              <div className='mt-2 flex gap-3'>
+                <Button
+                  halfWidth
+                  noMargins
+                  name='joinWithdraw'
+                  label='더 생각해 볼래요'
+                  className='bg-border text-dark m-0'
+                  size='md'
+                  onClick={onClose}
+                />
+                <Button
+                  halfWidth
+                  noMargins
+                  name='joinConfirm'
+                  label='참여할래요'
+                  className='m-0'
+                  size='md'
+                  onClick={onJoin}
+                />
+              </div>
+            </>
+          ) : (
+            <div className='grid h-10 place-items-center'>
+              <div className='flex flex-col gap-2'>참여에 실패했어요</div>
+            </div>
+          )}
         </Modal>
       )}
     </>

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -2,3 +2,5 @@ export { default as RoomContainer } from './RoomContainer';
 export { default as RoomHeader } from './RoomHeader';
 export { default as UserItem } from './UserItem';
 export { default as MenuBottomSheet } from './MenuBottomSheet';
+export { default as RoomJoinModal } from './RoomJoinModal';
+export { default as RoomJoinFriendModal } from './RoomJoinFriendModal';

--- a/src/widgets/user/ui/UserContainer.tsx
+++ b/src/widgets/user/ui/UserContainer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormItem, GroupCarousel } from '@/shared/ui';
 import { PATH } from '@/shared/constants';
 import { REQUEST } from '@/shared/api';
+import { logout } from '@/widgets/user/utils';
 
 export default function UserContainer() {
   return (
@@ -36,7 +37,11 @@ export default function UserContainer() {
         <button className='flex w-full justify-start focus:outline-none'>
           이용 약관
         </button>
-        <button className='mb-dock-height flex w-full justify-start focus:outline-none'>
+        <button
+          name='logout'
+          className='mb-dock-height text-important flex w-full justify-start focus:outline-none'
+          onClick={() => logout()}
+        >
           로그아웃
         </button>
       </FormItem>

--- a/src/widgets/user/ui/UserContainer.tsx
+++ b/src/widgets/user/ui/UserContainer.tsx
@@ -10,7 +10,7 @@ export default function UserContainer() {
     <>
       <Profile />
       <GroupCarousel
-        label='내가 만든 모임방'
+        label='참여한 모임방'
         to={PATH.LIST}
         request={REQUEST.ROOM_PARTICIPATED}
       />

--- a/src/widgets/user/utils/index.ts
+++ b/src/widgets/user/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './logout';

--- a/src/widgets/user/utils/logout.ts
+++ b/src/widgets/user/utils/logout.ts
@@ -1,0 +1,4 @@
+export const logout = () => {
+  sessionStorage.removeItem('userToken');
+  window.location.reload();
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용

> 모임방 세부 화면 UI가 변경되었어요.
- 모임방 세부 화면의 UI가 변경되었어요. 이제 예전보다 더 많은, 전체 정보를 제공해요.
- 모임방 세부 화면 참여 버튼을 사용자 상태에 따라 렌더링해요. 방장은 채팅방 이동, 참여 멤버는 채팅방 이동과 방 나가기, 미참여 멤버는 참여하기 버튼이 렌더링돼요.
- 모임방 인원 방식 (1:1, 2:2, 3:3)에 따라 참여하기 버튼과 참여 모달이 조건부로 렌더링돼요. 예를 들어, 2:2 모임방의 경우 친구와 함께 참여하기 버튼이 렌더링되고, 모달에는 한 명의 친구를 초대할 수 있는 `Input`이 렌더링돼요.
- 모임방 메뉴를 `BottomSheet` 를 사용하여 구현하였어요. 해당 컴포넌트가 공유됨에 따라, 공유 컴포넌트로 분리하고 `jotai` 와 `sheetKey`로 상태를 관리해요.
- `Modal`을 구현했어요. 해당 모달은 다른 곳에서도 사용될 예정이기 때문에, `BottomSheet`와 동일하게 공유 컴포넌트로 분리하고 상태 또한 전역으로 관리해요.

### 스크린샷 (선택)
| ![image1](https://github.com/user-attachments/assets/017d29e2-4d18-42d0-a45c-4bc675f23ce7) | ![image2](https://github.com/user-attachments/assets/51d9f6e4-8bf7-41f0-abf3-032dface9264) | ![image3](https://github.com/user-attachments/assets/c69173c1-5d10-4400-a435-62ff1902ef21) | ![image4](https://github.com/user-attachments/assets/02ce1483-3a99-4b7e-80ab-781aa562ae70) | ![image5](https://github.com/user-attachments/assets/389fe538-6b26-444b-b2a9-db0efd560334) |
|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|


