### PR TITLE
[FEAT] : 유저 상태에 따른 메뉴 렌더링, 하단 바 애니메이션

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -40,6 +40,7 @@
   --spacing-card-height: 160px;
   --spacing-normal-spacing: 18px;
   --spacing-normal-padding: 18px;
+  --spacing-bottom-spacing: 80px;
 }
 
 .agbalumo-regular {

--- a/src/screen/home/ui/HomeScreen.tsx
+++ b/src/screen/home/ui/HomeScreen.tsx
@@ -11,11 +11,14 @@ import { fetchLoginStatus } from '@/shared/utils';
 import { useBottomSheet } from '@/shared/hook';
 
 import { HomeContainer } from '@/widgets/home/ui';
+import { useStack } from '@stackflow/react';
 
 export default function HomeScreen() {
   const { openBottomSheet } = useBottomSheet();
   const { replace, push } = useFlow();
   const isLogin = fetchLoginStatus();
+  const stack = useStack();
+  const isLoading = stack.globalTransitionState === 'loading';
 
   const searchOnClick = () => replace(PATH.SEARCH, {});
   const createOnClick = () => {
@@ -43,7 +46,7 @@ export default function HomeScreen() {
         />
       </AppScreen>
       <LoginBottomSheet />
-      <Dock />
+      <Dock isLoading={isLoading} />
     </>
   );
 }

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
-import { ActivityComponentType } from '@stackflow/react';
+
+import { ActivityComponentType, useStack } from '@stackflow/react';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
+
 import { Button, RoomAppBar } from '@/shared/ui';
 import {
   MenuBottomSheet,
@@ -12,7 +14,7 @@ import {
 import { RoomAuthority, RoomListItem } from '@/shared/types';
 import { useBottomSheet, useModal } from '@/shared/hook';
 import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
-import { fetchLoginStatus } from '@/shared/utils';
+import { cn, fetchLoginStatus } from '@/shared/utils';
 import { useLeaveRoom } from '@/widgets/room/api';
 
 // 사용자 상태를 위한 타입 정의
@@ -30,8 +32,8 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
     status: 'pending',
     data: null,
   });
+  const stack = useStack();
   const [isLogin, setIsLogin] = useState<boolean>(false);
-
   const { maxParticipants, id, status: roomStatus } = params;
   const { mutate: leave } = useLeaveRoom(id);
   const { openBottomSheet } = useBottomSheet();
@@ -43,6 +45,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
 
   const availableFriendCnt = maxParticipants / 2 - 1;
   const isAvailableWithFriend = maxParticipants !== 2;
+  const isLoading = stack.globalTransitionState === 'loading';
 
   const handleMenuClick = () => {
     if (status.status === 'success') openBottomSheet(BOTTOM_SHEET.MENU);
@@ -155,7 +158,12 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
           <RoomContainer {...params} setStatus={setStatus} />
         </div>
       </AppScreen>
-      <div className='border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white'>
+      <div
+        className={cn(
+          'border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white transition-transform duration-300',
+          isLoading ? 'translate-y-full' : 'translate-y-0',
+        )}
+      >
         {renderActionButtons()}
       </div>
       <MenuBottomSheet roomAuthority={status.data} roomStatus={roomStatus} />

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -43,7 +43,9 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
   const availableFriendCnt = maxParticipants / 2 - 1;
   const isAvailableWithFriend = maxParticipants !== 2;
 
-  const handleMenuClick = () => openBottomSheet(BOTTOM_SHEET.MENU);
+  const handleMenuClick = () => {
+    if (status.status === 'success') openBottomSheet(BOTTOM_SHEET.MENU);
+  };
 
   const handleJoin = () => {
     if (isLogin) openModal(MODAL.JOIN);
@@ -147,7 +149,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
       <div className='border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white'>
         {renderActionButtons()}
       </div>
-      <MenuBottomSheet />
+      <MenuBottomSheet roomAuthority={status.data} roomId={id} />
       <RoomJoinModal roomId={id} />
       <RoomJoinFriendModal
         availableFriendCnt={availableFriendCnt}

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -31,7 +31,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
   });
   const [isLogin, setIsLogin] = useState<boolean>(false);
 
-  const { maxParticipants, id } = params;
+  const { maxParticipants, id, status: roomStatus } = params;
   const { mutate: leave } = useLeaveRoom(id);
   const { openBottomSheet } = useBottomSheet();
   const { openModal } = useModal();
@@ -120,18 +120,26 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
 
     return (
       <>
-        {isAvailableWithFriend ? (
-          <Button
-            name='room-participate-with-friend'
-            label='친구와 함께 참여하기'
-            onClick={handleJoinWithFriend}
-            className='mb-normal-spacing'
-          />
+        {roomStatus === 'MATCHING' ? (
+          isAvailableWithFriend ? (
+            <Button
+              name='room-participate-with-friend'
+              label='친구와 함께 참여하기'
+              onClick={handleJoinWithFriend}
+              className='mb-normal-spacing'
+            />
+          ) : (
+            <Button
+              name='room-participate'
+              label='참여하기'
+              onClick={handleJoin}
+              className='mb-normal-spacing'
+            />
+          )
         ) : (
           <Button
-            name='room-participate'
-            label='참여하기'
-            onClick={handleJoin}
+            label='매칭이 종료되었어요'
+            disabled
             className='mb-normal-spacing'
           />
         )}

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -5,6 +5,7 @@ import { Button, RoomAppBar } from '@/shared/ui';
 import {
   MenuBottomSheet,
   RoomContainer,
+  RoomDeleteModal,
   RoomJoinFriendModal,
   RoomJoinModal,
 } from '@/widgets/room/ui';
@@ -157,7 +158,8 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
       <div className='border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white'>
         {renderActionButtons()}
       </div>
-      <MenuBottomSheet roomAuthority={status.data} roomId={id} />
+      <MenuBottomSheet roomAuthority={status.data} />
+      <RoomDeleteModal roomId={id} />
       <RoomJoinModal roomId={id} />
       <RoomJoinFriendModal
         availableFriendCnt={availableFriendCnt}

--- a/src/screen/room/ui/RoomScreen.tsx
+++ b/src/screen/room/ui/RoomScreen.tsx
@@ -158,7 +158,7 @@ const RoomScreen: ActivityComponentType<RoomListItem> = ({
       <div className='border-t-app-bar-border fixed bottom-0 z-30 flex h-fit w-full gap-x-3 border-[0.5px] bg-white px-6 py-6 text-lg font-semibold text-white'>
         {renderActionButtons()}
       </div>
-      <MenuBottomSheet roomAuthority={status.data} />
+      <MenuBottomSheet roomAuthority={status.data} roomStatus={roomStatus} />
       <RoomDeleteModal roomId={id} />
       <RoomJoinModal roomId={id} />
       <RoomJoinFriendModal

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -12,12 +12,6 @@ interface GetRequestParams<TParams> {
   params?: TParams;
 }
 
-interface PutRequestParams<TData> {
-  request: string;
-  headers?: AxiosHeaders;
-  data: TData;
-}
-
 const instance = axios.create({
   baseURL: 'https://www.festamate.shop/api',
 });
@@ -105,7 +99,7 @@ export async function userPost<TData, TResponse = unknown>(
 }
 
 export async function userPut<TData, TResponse = unknown>(
-  config: PutRequestParams<TData>,
+  config: PostRequestParams<TData>,
 ): Promise<AxiosResponse<TResponse>> {
   const { request, headers, data } = config;
   try {
@@ -114,6 +108,45 @@ export async function userPut<TData, TResponse = unknown>(
       AxiosResponse<TResponse>,
       TData
     >(request, data, { headers: headers || undefined });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userDel<TResponse = unknown>(
+  config: Omit<PostRequestParams<unknown>, 'data'>,
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers } = config;
+  try {
+    const response = await instance.delete<TResponse, AxiosResponse<TResponse>>(
+      request,
+      {
+        headers: headers || undefined,
+      },
+    );
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userPatch<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>,
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.patch<
+      TResponse,
+      AxiosResponse<TResponse>,
+      TData
+    >(request, data, {
+      headers: headers || undefined,
+    });
     return response;
   } catch (error: unknown) {
     console.log(error);

--- a/src/shared/constants/modal.ts
+++ b/src/shared/constants/modal.ts
@@ -1,4 +1,5 @@
 export const MODAL = {
   JOIN: 'joinModal',
   JOIN_WITH_FRIEND: 'joinWithFriendModal',
+  ROOM_DELETE: 'deleteRoomModal',
 } as const;

--- a/src/shared/constants/modal.ts
+++ b/src/shared/constants/modal.ts
@@ -2,4 +2,5 @@ export const MODAL = {
   JOIN: 'joinModal',
   JOIN_WITH_FRIEND: 'joinWithFriendModal',
   ROOM_DELETE: 'deleteRoomModal',
+  ROOM_DELETE_DENIAL: 'deleteRoomDenialModal',
 } as const;

--- a/src/shared/constants/status.ts
+++ b/src/shared/constants/status.ts
@@ -1,4 +1,6 @@
-export const ROOM_STATUS: Record<string, string> = {
+import { RoomStatus } from '@/shared/types';
+
+export const ROOM_STATUS: Record<RoomStatus, string> = {
   MATCHING: '매칭중',
   MATCHED: '매칭 완료',
   CLOSED: '모임 종료',

--- a/src/shared/types/room.ts
+++ b/src/shared/types/room.ts
@@ -1,9 +1,17 @@
 import { Gender } from '@/shared/types';
 
+export type RoomStatus = 'MATCHING' | 'MATCHED' | 'CLOSED';
+
+export type RoomAuthority =
+  | 'HOST'
+  | 'PARTICIPANT'
+  | 'NON_PARTICIPANT'
+  | 'NON_MEMBER';
+
 export type Room = Partial<FormData> & {
   id: number;
   maxParticipants: 2 | 4 | 6;
-  status: string;
+  status: RoomStatus;
   preferredGender: Gender;
   preferredStudentIdMin: string;
   preferredStudentIdMax: string;
@@ -12,12 +20,6 @@ export type Room = Partial<FormData> & {
   content: string;
   place: string;
 };
-
-export type RoomAuthority =
-  | 'HOST'
-  | 'PARTICIPANT'
-  | 'NON_PARTICIPANT'
-  | 'NON_MEMBER';
 
 export type RoomDetail = RoomListItem & {
   roomAuthority: RoomAuthority;

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -36,7 +36,7 @@ export default function Button({
       name={name}
       type={type || 'button'}
       className={cn(
-        'hover:bg-point-hover bg-point text-md disabled:bg-sub disabled:text-border flex-shrink-0 cursor-pointer font-medium text-white transition duration-300',
+        'hover:bg-point-hover bg-point text-md disabled:bg-sub flex-shrink-0 cursor-pointer font-medium text-white transition duration-300 disabled:text-gray-300',
         halfWidth ? 'flex-1' : 'w-full',
         shadow && 'box-shadow-button',
         className,

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -31,7 +31,7 @@ export default function Dock(isLoading: DockProps) {
       {render && (
         <div
           className={cn(
-            'dock box-shadow-dock container-mobile h-dock-height p-normal-spacing fixed right-0 bottom-0 left-0 z-60 flex items-center justify-between border-none',
+            'dock box-shadow-dock container-mobile h-dock-height p-normal-spacing fixed right-0 bottom-0 left-0 z-60 flex items-center justify-between border-none pb-10',
             isLoading ? 'translate-y-0' : 'translate-y-full',
           )}
         >

--- a/src/shared/ui/Dock.tsx
+++ b/src/shared/ui/Dock.tsx
@@ -5,15 +5,19 @@ import { useFlow } from '@/app/stackflow';
 
 import { BOTTOM_SHEET, DOCK, DOCK_ITEMS, PATH } from '@/shared/constants';
 import { DockItem, PathItem } from '@/shared/types';
-import { fetchLoginStatus } from '@/shared/utils';
+import { cn, fetchLoginStatus } from '@/shared/utils';
 import { useBottomSheet } from '@/shared/hook';
+
+interface DockProps {
+  isLoading?: boolean;
+}
 
 interface DockButtonProps {
   item: DockItem;
   selected: boolean;
 }
 
-export default function Dock() {
+export default function Dock(isLoading: DockProps) {
   const stack = useStack();
   const info = stack.activities;
   const current = info
@@ -25,7 +29,12 @@ export default function Dock() {
   return (
     <>
       {render && (
-        <div className='dock box-shadow-dock container-mobile h-dock-height p-normal-spacing fixed right-0 bottom-0 left-0 z-60 flex items-center justify-between border-none'>
+        <div
+          className={cn(
+            'dock box-shadow-dock container-mobile h-dock-height p-normal-spacing fixed right-0 bottom-0 left-0 z-60 flex items-center justify-between border-none',
+            isLoading ? 'translate-y-0' : 'translate-y-full',
+          )}
+        >
           {DOCK_ITEMS.map(item => (
             <DockButton key={item} item={item} selected={current === item} />
           ))}

--- a/src/shared/ui/GroupList.tsx
+++ b/src/shared/ui/GroupList.tsx
@@ -21,7 +21,7 @@ export default function GroupList({ label, to, request }: GroupListProps) {
   const rooms = data ? data.content : [];
 
   return (
-    <div className='flex w-full flex-col gap-y-3'>
+    <div className='flex w-full flex-col'>
       <div className='flex items-baseline justify-between gap-x-2'>
         <span className='text-lg font-semibold'>{label}</span>
         <button
@@ -32,7 +32,7 @@ export default function GroupList({ label, to, request }: GroupListProps) {
           <u>더보기</u>
         </button>
       </div>
-      <div className='flex flex-col items-center gap-1.5'>
+      <div className='mb-3 flex flex-col items-center gap-1.5'>
         {data && (
           <>
             {rooms.length === 0 ? (

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, type ReactNode } from 'react';
 
 import { ModalItem } from '@/shared/types';
-import { useModal, useOutsideClick } from '../hook';
+import { useModal, useOutsideClick } from '@/shared/hook';
 
 interface ModalProps {
   children: ReactNode;

--- a/src/widgets/room/api/delete.ts
+++ b/src/widgets/room/api/delete.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { REQUEST, userDel, useRoomList } from '@/shared/api';
+import { getPath } from '@/shared/utils';
+
+interface DeleteRoomResponse {
+  isSuccess: boolean;
+  message: string;
+}
+
+const deleteRoom = async (roomId: number) => {
+  await userDel<DeleteRoomResponse>({
+    request: getPath(REQUEST.ROOM, `${roomId}`),
+  });
+};
+
+export const useDeleteRoom = () => {
+  const { refetch } = useRoomList(REQUEST.ROOM);
+
+  return useMutation({
+    mutationFn: deleteRoom,
+    onSuccess: () => {
+      refetch();
+      window.location.replace(`${import.meta.env.VITE_PRODUCTION_URL}`);
+    },
+  });
+};

--- a/src/widgets/room/api/index.ts
+++ b/src/widgets/room/api/index.ts
@@ -1,3 +1,4 @@
 export * from './room';
 export * from './join';
 export * from './leave';
+export * from './delete';

--- a/src/widgets/room/ui/MenuBottomSheet.tsx
+++ b/src/widgets/room/ui/MenuBottomSheet.tsx
@@ -3,20 +3,56 @@ import React from 'react';
 import { BottomSheet, Button } from '@/shared/ui';
 import { BOTTOM_SHEET } from '@/shared/constants';
 import { useBottomSheet } from '@/shared/hook';
+import { RoomAuthority } from '@/shared/types';
 
-export default function MenuBottomSheet() {
+import { useDeleteRoom } from '@/widgets/room/api';
+
+interface MenuBottomSheetProps {
+  roomAuthority: RoomAuthority | null;
+  roomId: number;
+}
+
+export default function MenuBottomSheet({
+  roomAuthority,
+  roomId,
+}: MenuBottomSheetProps) {
   const { closeBottomSheet, bottomSheetState } = useBottomSheet();
   const { isOpen } = bottomSheetState(BOTTOM_SHEET.MENU);
+  const { mutate } = useDeleteRoom();
+
+  const handleDelete = () => mutate(roomId);
+
+  const renderMenu = (roomAuthority: RoomAuthority) => {
+    if (roomAuthority === 'HOST') {
+      return (
+        <>
+          <button className='w-full cursor-pointer py-1'>모임방 수정</button>
+          <button
+            name='roomDelete'
+            className='text-important w-full cursor-pointer py-1'
+            onClick={handleDelete}
+          >
+            모임방 삭제
+          </button>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <button className='text-important w-full cursor-pointer py-1'>
+          모임방 신고
+        </button>
+      </>
+    );
+  };
 
   return (
     <>
       {isOpen && (
         <BottomSheet sheetKey={BOTTOM_SHEET.MENU}>
           <div className='flex flex-col gap-3'>
-            <button className='w-full cursor-pointer py-1'>모임방 수정</button>
-            <button className='text-important w-full cursor-pointer py-1'>
-              모임방 신고
-            </button>
+            {roomAuthority && renderMenu(roomAuthority)}
           </div>
           <Button
             size='md'

--- a/src/widgets/room/ui/MenuBottomSheet.tsx
+++ b/src/widgets/room/ui/MenuBottomSheet.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
 
 import { BottomSheet, Button } from '@/shared/ui';
-import { BOTTOM_SHEET } from '@/shared/constants';
-import { useBottomSheet } from '@/shared/hook';
+import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
+import { useBottomSheet, useModal } from '@/shared/hook';
 import { RoomAuthority } from '@/shared/types';
-
-import { useDeleteRoom } from '@/widgets/room/api';
 
 interface MenuBottomSheetProps {
   roomAuthority: RoomAuthority | null;
-  roomId: number;
 }
 
 export default function MenuBottomSheet({
   roomAuthority,
-  roomId,
 }: MenuBottomSheetProps) {
   const { closeBottomSheet, bottomSheetState } = useBottomSheet();
+  const { openModal } = useModal();
   const { isOpen } = bottomSheetState(BOTTOM_SHEET.MENU);
-  const { mutate } = useDeleteRoom();
 
-  const handleDelete = () => mutate(roomId);
+  const handleDelete = () => {
+    closeBottomSheet(BOTTOM_SHEET.MENU);
+    openModal(MODAL.ROOM_DELETE);
+  };
 
   const renderMenu = (roomAuthority: RoomAuthority) => {
     if (roomAuthority === 'HOST') {

--- a/src/widgets/room/ui/MenuBottomSheet.tsx
+++ b/src/widgets/room/ui/MenuBottomSheet.tsx
@@ -3,14 +3,16 @@ import React from 'react';
 import { BottomSheet, Button } from '@/shared/ui';
 import { BOTTOM_SHEET, MODAL } from '@/shared/constants';
 import { useBottomSheet, useModal } from '@/shared/hook';
-import { RoomAuthority } from '@/shared/types';
+import { RoomAuthority, RoomStatus } from '@/shared/types';
 
 interface MenuBottomSheetProps {
   roomAuthority: RoomAuthority | null;
+  roomStatus: RoomStatus;
 }
 
 export default function MenuBottomSheet({
   roomAuthority,
+  roomStatus,
 }: MenuBottomSheetProps) {
   const { closeBottomSheet, bottomSheetState } = useBottomSheet();
   const { openModal } = useModal();
@@ -18,7 +20,8 @@ export default function MenuBottomSheet({
 
   const handleDelete = () => {
     closeBottomSheet(BOTTOM_SHEET.MENU);
-    openModal(MODAL.ROOM_DELETE);
+    if (roomStatus === 'MATCHING') openModal(MODAL.ROOM_DELETE);
+    else openModal(MODAL.ROOM_DELETE_DENIAL);
   };
 
   const renderMenu = (roomAuthority: RoomAuthority) => {

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -55,7 +55,7 @@ export default function RoomContainer(props: RoomContainerProps) {
                 <UserItem {...m} key={m.id} />
               ))}
             </FormItem>
-            <FormItem title='모임에 참여한 멤버'>
+            <FormItem title='모임에 참여한 멤버' className='mb-24'>
               {data.guestParticipants.map(m => {
                 if (!m.isHost) return <UserItem {...m} key={m.id} />;
               })}
@@ -67,7 +67,6 @@ export default function RoomContainer(props: RoomContainerProps) {
             </FormItem>
           </>
         )}
-        <div className='h-normal-spacing' />
       </div>
     </div>
   );

--- a/src/widgets/room/ui/RoomContainer.tsx
+++ b/src/widgets/room/ui/RoomContainer.tsx
@@ -55,7 +55,7 @@ export default function RoomContainer(props: RoomContainerProps) {
                 <UserItem {...m} key={m.id} />
               ))}
             </FormItem>
-            <FormItem title='모임에 참여한 멤버' className='mb-24'>
+            <FormItem title='모임에 참여한 멤버' className='mb-bottom-spacing'>
               {data.guestParticipants.map(m => {
                 if (!m.isHost) return <UserItem {...m} key={m.id} />;
               })}

--- a/src/widgets/room/ui/RoomDeleteDenialModal.tsx
+++ b/src/widgets/room/ui/RoomDeleteDenialModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { MODAL } from '@/shared/constants';
+import { Button, Modal } from '@/shared/ui';
+import { useModal } from '@/shared/hook';
+
+export default function RoomDeleteDenialModal() {
+  const { closeModal, modalState } = useModal();
+  const { isOpen } = modalState(MODAL.ROOM_DELETE_DENIAL);
+
+  const onClose = () => closeModal(MODAL.ROOM_DELETE_DENIAL);
+
+  return (
+    <>
+      {isOpen && (
+        <Modal modalKey={MODAL.ROOM_DELETE_DENIAL}>
+          <>
+            <p className='text-lg font-semibold'>모임방 삭제</p>
+            <p>
+              이미 매칭이 완료되거나, 미팅이 종료된 모임방은 삭제할 수 없어요.
+            </p>
+            <div className='mt-2 flex gap-3'>
+              <Button
+                name='impossibleDelete'
+                label='확인했어요'
+                size='md'
+                onClick={onClose}
+              />
+            </div>
+          </>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/widgets/room/ui/RoomDeleteModal.tsx
+++ b/src/widgets/room/ui/RoomDeleteModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { MODAL } from '@/shared/constants';
+import { Button, Modal } from '@/shared/ui';
+import { useModal } from '@/shared/hook';
+
+import { useDeleteRoom } from '@/widgets/room/api';
+
+interface RoomDeleteModalProps {
+  roomId: number;
+}
+
+export default function RoomDeleteModal({ roomId }: RoomDeleteModalProps) {
+  const { closeModal, modalState } = useModal();
+  const { mutate, isError } = useDeleteRoom();
+  const { isOpen } = modalState(MODAL.ROOM_DELETE);
+
+  const onClose = () => closeModal(MODAL.ROOM_DELETE);
+  const onJoin = () => mutate(roomId);
+
+  return (
+    <>
+      {isOpen && (
+        <Modal modalKey={MODAL.ROOM_DELETE}>
+          {!isError ? (
+            <>
+              <p className='text-lg font-semibold'>모임방 삭제</p>
+              <p>정말 모임방을 삭제할까요?</p>
+              <div className='mt-2 flex gap-3'>
+                <Button
+                  halfWidth
+                  noMargins
+                  name='deleteWithdraw'
+                  label='더 생각해 볼래요'
+                  className='bg-border text-dark m-0'
+                  size='md'
+                  onClick={onClose}
+                />
+                <Button
+                  halfWidth
+                  noMargins
+                  name='deleteConfirm'
+                  label='삭제할게요'
+                  className='m-0'
+                  size='md'
+                  onClick={onJoin}
+                />
+              </div>
+            </>
+          ) : (
+            <div className='grid h-10 place-items-center'>
+              <div className='flex flex-col gap-2'>참여에 실패했어요</div>
+            </div>
+          )}
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/widgets/room/ui/RoomHeader.tsx
+++ b/src/widgets/room/ui/RoomHeader.tsx
@@ -5,7 +5,7 @@ import { GENDER, ROOM_STATUS } from '@/shared/constants';
 import { GoClockFill } from 'react-icons/go';
 import { RiUser3Fill } from 'react-icons/ri';
 import { IoLocationSharp } from 'react-icons/io5';
-import { getDate } from '@/shared/utils';
+import { cn, getDate } from '@/shared/utils';
 
 export default function RoomHeader(props: RoomListItem) {
   const {
@@ -34,10 +34,24 @@ export default function RoomHeader(props: RoomListItem) {
             {title}
           </p>
           <p className='flex items-center gap-2 text-sm text-white'>
-            <span className='border-border rounded-full border-1 bg-white/20 px-2 py-1'>
+            <span
+              className={cn(
+                'rounded-full border-1 px-2 py-1',
+                preferredGender === 'MALE'
+                  ? 'border-male bg-male/20'
+                  : 'border-female bg-female/20',
+              )}
+            >
               {GENDER[preferredGender]}
             </span>
-            <span className='border-border rounded-full border-1 bg-white/20 px-2 py-1'>
+            <span
+              className={cn(
+                'rounded-full border-1 bg-white/20 px-2 py-1',
+                status === 'MATCHING' && 'border-yellow-500',
+                status === 'MATCHED' && 'border-green-500',
+                status === 'CLOSED' && 'border-border',
+              )}
+            >
               {ROOM_STATUS[status]}
             </span>
           </p>

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -5,3 +5,4 @@ export { default as MenuBottomSheet } from './MenuBottomSheet';
 export { default as RoomJoinModal } from './RoomJoinModal';
 export { default as RoomJoinFriendModal } from './RoomJoinFriendModal';
 export { default as RoomDeleteModal } from './RoomDeleteModal';
+export { default as RoomDeleteDenialModal } from './RoomDeleteDenialModal';

--- a/src/widgets/room/ui/index.ts
+++ b/src/widgets/room/ui/index.ts
@@ -4,3 +4,4 @@ export { default as UserItem } from './UserItem';
 export { default as MenuBottomSheet } from './MenuBottomSheet';
 export { default as RoomJoinModal } from './RoomJoinModal';
 export { default as RoomJoinFriendModal } from './RoomJoinFriendModal';
+export { default as RoomDeleteModal } from './RoomDeleteModal';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #27 

## 📝 작업 내용

> 유저 참여 상태에 따라 모임방 메뉴에 렌더링되는 메뉴 항목이 달라졌어요.
- 모임방 삭제 기능을 구현했고, 삭제 시 모달을 띄워 여부를 한 번 더 확인하도록 구현했어요.
- 모임방 삭제 시 매칭이 완료된 상태일 경우 삭제할 수 없음 여부를 표시하는 모달을 표시하도록 구현했어요.
- 모임방 상세 화면으로 이동 시 상세 화면 아래 버튼이 아래에서 올라오는 애니메이션이 적용되었어요.
- `Dock` 의 아래쪽 padding을 높여 모바일에서 더욱 좋은 접근성을 가질 수 있도록 했어요.

### 스크린샷 (선택)

| 방장 메뉴 | 참여자 / 미참여자 메뉴 | 방 삭제 시 모달 |
|:-------:|:-------:|:-------:|
| <img src="https://github.com/user-attachments/assets/c45bd98f-bcb0-46be-87e0-22a33d63c711" width="150" /> | <img src="https://github.com/user-attachments/assets/6a35d8c8-2e58-4246-bd7d-a922389e624c" width="150" /> | <img src="https://github.com/user-attachments/assets/fc10b797-04c0-46ac-895c-f19b3ada484d" width="150" /> |


